### PR TITLE
Routing management

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'routes.dart';
 import 'pages/structure.dart';
 
 // sqflite
@@ -119,7 +120,8 @@ class Launcher extends StatelessWidget {
     return MaterialApp(
       title: 'Sossoldi',
       theme: customThemeData,
-      home: const Structure(),
+      onGenerateRoute: makeRoute,
+      initialRoute: '/',
     );
   }
 }

--- a/lib/pages/add_page.dart
+++ b/lib/pages/add_page.dart
@@ -30,16 +30,7 @@ class _AddPageState extends State<AddPage> {
             onPressed: () {}),
         actions: [
           IconButton(
-            onPressed: () {
-              Navigator.push(
-                  context,
-                  PageRouteBuilder(
-                    pageBuilder: (context, animation1, animation2) =>
-                        SettingsPage(),
-                    transitionDuration: Duration.zero,
-                    reverseTransitionDuration: Duration.zero,
-                  ));
-            },
+            onPressed: () => Navigator.of(context).pushNamed('/settings'),
             icon: const Icon(Icons.settings),
           )
         ],

--- a/lib/pages/structure.dart
+++ b/lib/pages/structure.dart
@@ -74,16 +74,7 @@ class _StructureState extends State<Structure> {
           Padding(
             padding: const EdgeInsets.all(8.0),
             child: ElevatedButton(
-              onPressed: () {
-                Navigator.push(
-                  context,
-                  PageRouteBuilder(
-                    pageBuilder: (context, animation1, animation2) => SettingsPage(),
-                    transitionDuration: Duration.zero,
-                    reverseTransitionDuration: Duration.zero,
-                  ),
-                );
-              },
+              onPressed: () => Navigator.of(context).pushNamed('/settings'),
               style: ElevatedButton.styleFrom(
                 elevation: 0,
                 shape: const CircleBorder(),
@@ -125,16 +116,7 @@ class _StructureState extends State<Structure> {
           size: 55,
           color: Color.fromRGBO(93, 93, 93, 1),
         ),
-        onPressed: () {
-          Navigator.push(
-            context,
-            PageRouteBuilder(
-              pageBuilder: (context, animation1, animation2) => AddPage(),
-              transitionDuration: Duration.zero,
-              reverseTransitionDuration: Duration.zero,
-            ),
-          );
-        },
+        onPressed: () => Navigator.of(context).pushNamed('/add'),
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.miniCenterDocked,
     );

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -57,16 +57,3 @@ PageRoute _noTransitionPageRoute(String? routeName, Widget viewToShow) {
     pageBuilder: (_, __, ___) => viewToShow,
   );
 }
-
-class NoAnimationPageRoute extends MaterialPageRoute {
-  NoAnimationPageRoute({builder, settings}) : super(builder: builder, settings: settings);
-
-  @override
-  Duration get transitionDuration => const Duration(milliseconds: 0);
-
-  @override
-  Widget buildTransitions(BuildContext context, Animation<double> animation,
-      Animation<double> secondaryAnimation, Widget child) {
-    return FadeTransition(opacity: animation, child: child);
-  }
-}

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'pages/add_page.dart';
+import 'pages/home_page.dart';
+import 'pages/planning_budget_page.dart';
+import 'pages/settings_page.dart';
+import 'pages/statistics_page.dart';
+import 'pages/structure.dart';
+import 'pages/transactions_page/transactions_page.dart';
+
+Route<dynamic> makeRoute(RouteSettings settings) {
+  switch (settings.name) {
+    case '/':
+      return _materialPageRoute(settings.name, const Structure());
+    case '/dashboard':
+      return _materialPageRoute(settings.name, const HomePage());
+    case '/transactions':
+      return _materialPageRoute(settings.name, TransactionsPage());
+    case '/planning':
+      return _materialPageRoute(settings.name, PlanningPage());
+    case '/graphs':
+      return _materialPageRoute(settings.name, StatsPage());
+    case '/add':
+      return _noTransitionPageRoute(settings.name, AddPage());
+    case '/settings':
+      return _noTransitionPageRoute(settings.name, SettingsPage());
+    default:
+      throw 'Route is not defined';
+  }
+}
+
+PageRoute _cupertinoPageRoute(String? routeName, Widget viewToShow) {
+  return CupertinoPageRoute(
+    settings: RouteSettings(
+      name: routeName,
+    ),
+    builder: (_) => viewToShow,
+  );
+}
+
+PageRoute _materialPageRoute(String? routeName, Widget viewToShow) {
+  return MaterialPageRoute(
+    settings: RouteSettings(
+      name: routeName,
+    ),
+    builder: (_) => viewToShow,
+  );
+}
+
+PageRoute _noTransitionPageRoute(String? routeName, Widget viewToShow) {
+  return PageRouteBuilder(
+    transitionDuration: const Duration(),
+    reverseTransitionDuration: const Duration(),
+    settings: RouteSettings(
+      name: routeName,
+    ),
+    pageBuilder: (_, __, ___) => viewToShow,
+  );
+}
+
+class NoAnimationPageRoute extends MaterialPageRoute {
+  NoAnimationPageRoute({builder, settings}) : super(builder: builder, settings: settings);
+
+  @override
+  Duration get transitionDuration => const Duration(milliseconds: 0);
+
+  @override
+  Widget buildTransitions(BuildContext context, Animation<double> animation,
+      Animation<double> secondaryAnimation, Widget child) {
+    return FadeTransition(opacity: animation, child: child);
+  }
+}


### PR DESCRIPTION
Implemented a routing management system and added named routes.

Example for using it:
 You want to navigate to '/settings' > `Navigator.of(context).pushNamed('/settings');`

Adding a new route inside routes.dart:
 ```
 case '/example':
      return _materialPageRoute(settings.name, ExamplePage());
 ```

There is 3 different types of page route animation:

- _cupertinoPageRoute
- _materialPageRoute
- _noTransitionPageRoute