### PR TITLE
Rename field in recurringTransactionAmount

### DIFF
--- a/lib/database/sossoldi_database.dart
+++ b/lib/database/sossoldi_database.dart
@@ -86,7 +86,7 @@ class SossoldiDatabase {
         `${RecurringTransactionAmountFields.from}` $textNotNull,
         `${RecurringTransactionAmountFields.to}` $textNotNull,
         `${RecurringTransactionAmountFields.amount}` $realNotNull,
-        `${RecurringTransactionAmountFields.idRecurringTransaction}` $integerNotNull,
+        `${RecurringTransactionAmountFields.idTransaction}` $integerNotNull,
         `${RecurringTransactionAmountFields.createdAt}` $textNotNull,
         `${RecurringTransactionAmountFields.updatedAt}` $textNotNull
       )

--- a/lib/model/recurring_transaction_amount.dart
+++ b/lib/model/recurring_transaction_amount.dart
@@ -8,7 +8,7 @@ class RecurringTransactionAmountFields extends BaseEntityFields {
   static String from = 'from';
   static String to = 'to';
   static String amount = 'amount';
-  static String idRecurringTransaction = 'idRecurringTransaction'; // FK
+  static String idTransaction = 'idTransaction'; // FK
   static String createdAt = BaseEntityFields.getCreatedAt;
   static String updatedAt = BaseEntityFields.getUpdatedAt;
 
@@ -17,7 +17,7 @@ class RecurringTransactionAmountFields extends BaseEntityFields {
     from,
     to,
     amount,
-    idRecurringTransaction,
+    idTransaction,
     BaseEntityFields.createdAt,
     BaseEntityFields.updatedAt
   ];
@@ -27,14 +27,14 @@ class RecurringTransactionAmount extends BaseEntity {
   final DateTime from;
   final DateTime to;
   final num amount;
-  final int? idRecurringTransaction;
+  final int? idTransaction;
 
   const RecurringTransactionAmount(
       {int? id,
       required this.from,
       required this.to,
       required this.amount,
-      required this.idRecurringTransaction,
+      required this.idTransaction,
       DateTime? createdAt,
       DateTime? updatedAt})
       : super(id: id, createdAt: createdAt, updatedAt: updatedAt);
@@ -44,7 +44,7 @@ class RecurringTransactionAmount extends BaseEntity {
           DateTime? from,
           DateTime? to,
           num? amount,
-          int? idRecurringTransaction,
+          int? idTransaction,
           DateTime? createdAt,
           DateTime? updatedAt}) =>
       RecurringTransactionAmount(
@@ -52,8 +52,8 @@ class RecurringTransactionAmount extends BaseEntity {
           from: from ?? this.from,
           to: to ?? this.to,
           amount: amount ?? this.amount,
-          idRecurringTransaction:
-              idRecurringTransaction ?? this.idRecurringTransaction,
+          idTransaction:
+              idTransaction ?? this.idTransaction,
           createdAt: createdAt ?? this.createdAt,
           updatedAt: updatedAt ?? this.updatedAt);
 
@@ -65,8 +65,8 @@ class RecurringTransactionAmount extends BaseEntity {
           to: DateTime.parse(
               json[RecurringTransactionAmountFields.to] as String),
           amount: json[RecurringTransactionAmountFields.amount] as num,
-          idRecurringTransaction:
-              json[RecurringTransactionAmountFields.idRecurringTransaction]
+          idTransaction:
+              json[RecurringTransactionAmountFields.idTransaction]
                   as int,
           createdAt: DateTime.parse(json[BaseEntityFields.createdAt] as String),
           updatedAt:
@@ -77,8 +77,8 @@ class RecurringTransactionAmount extends BaseEntity {
         RecurringTransactionAmountFields.from: from.toIso8601String(),
         RecurringTransactionAmountFields.to: to.toIso8601String(),
         RecurringTransactionAmountFields.amount: amount,
-        RecurringTransactionAmountFields.idRecurringTransaction:
-            idRecurringTransaction,
+        RecurringTransactionAmountFields.idTransaction:
+            idTransaction,
         BaseEntityFields.createdAt: createdAt?.toIso8601String(),
         BaseEntityFields.updatedAt: updatedAt?.toIso8601String(),
       };

--- a/test/model/recurring_transaction_amount_test.dart
+++ b/test/model/recurring_transaction_amount_test.dart
@@ -10,7 +10,7 @@ void main() {
         from: DateTime.utc(2022),
         to: DateTime.utc(2023),
         amount: 0,
-        idRecurringTransaction: 0,
+        idTransaction: 0,
         createdAt: DateTime.utc(2022),
         updatedAt: DateTime.utc(2022));
 
@@ -20,7 +20,7 @@ void main() {
     assert(tCopy.from == t.from);
     assert(tCopy.to == t.to);
     assert(tCopy.amount == t.amount);
-    assert(tCopy.idRecurringTransaction == t.idRecurringTransaction);
+    assert(tCopy.idTransaction == t.idTransaction);
     assert(tCopy.createdAt == t.createdAt);
     assert(tCopy.updatedAt == t.updatedAt);
   });
@@ -32,7 +32,7 @@ void main() {
           DateTime.utc(2022).toIso8601String(),
       RecurringTransactionAmountFields.to: DateTime.utc(2023).toIso8601String(),
       RecurringTransactionAmountFields.amount: 0,
-      RecurringTransactionAmountFields.idRecurringTransaction: 0,
+      RecurringTransactionAmountFields.idTransaction: 0,
       BaseEntityFields.createdAt: DateTime.utc(2022).toIso8601String(),
       BaseEntityFields.updatedAt: DateTime.utc(2022).toIso8601String(),
     };
@@ -45,8 +45,8 @@ void main() {
     assert(t.to.toUtc().toIso8601String() ==
         json[RecurringTransactionAmountFields.to]);
     assert(t.amount == json[RecurringTransactionAmountFields.amount]);
-    assert(t.idRecurringTransaction ==
-        json[RecurringTransactionAmountFields.idRecurringTransaction]);
+    assert(t.idTransaction ==
+        json[RecurringTransactionAmountFields.idTransaction]);
     assert(t.createdAt?.toUtc().toIso8601String() ==
         json[BaseEntityFields.createdAt]);
     assert(t.updatedAt?.toUtc().toIso8601String() ==
@@ -59,7 +59,7 @@ void main() {
         from: DateTime.utc(2022),
         to: DateTime.utc(2023),
         amount: 0,
-        idRecurringTransaction: 0,
+        idTransaction: 0,
         createdAt: DateTime.utc(2022),
         updatedAt: DateTime.utc(2022));
 
@@ -71,8 +71,8 @@ void main() {
     assert(t.to.toUtc().toIso8601String() ==
         json[RecurringTransactionAmountFields.to]);
     assert(t.amount == json[RecurringTransactionAmountFields.amount]);
-    assert(t.idRecurringTransaction ==
-        json[RecurringTransactionAmountFields.idRecurringTransaction]);
+    assert(t.idTransaction ==
+        json[RecurringTransactionAmountFields.idTransaction]);
     assert(t.createdAt?.toUtc().toIso8601String() ==
         json[BaseEntityFields.createdAt]);
     assert(t.updatedAt?.toUtc().toIso8601String() ==


### PR DESCRIPTION
Renamed `idRecurringTransaction` field to `idTransaction` (following recent db scheme changes).