### PR TITLE
Improvements to "Transactions" page

### DIFF
--- a/lib/pages/transactions_page/transactions_page.dart
+++ b/lib/pages/transactions_page/transactions_page.dart
@@ -6,8 +6,10 @@ import 'widgets/accounts_tab.dart';
 import 'widgets/list_tab.dart';
 
 class TransactionsPage extends StatefulWidget {
+  const TransactionsPage({super.key});
+
   @override
-  _TransactionsPageState createState() => _TransactionsPageState();
+  State<TransactionsPage> createState() => _TransactionsPageState();
 }
 
 class _TransactionsPageState extends State<TransactionsPage>

--- a/lib/pages/transactions_page/widgets/categories_pie_chart.dart
+++ b/lib/pages/transactions_page/widgets/categories_pie_chart.dart
@@ -1,18 +1,23 @@
 import "package:flutter/material.dart";
 import 'package:fl_chart/fl_chart.dart';
-import 'package:sossoldi/constants/style.dart';
 
+import '../../../constants/functions.dart';
+import '../../../constants/style.dart';
 import '../../../model/category_transaction.dart';
 
-class CategoriesPieChart extends StatelessWidget {
+class CategoriesPieChart extends StatelessWidget with Functions {
   const CategoriesPieChart({
     required this.notifier,
     required this.categories,
+    required this.amounts,
+    required this.total,
     Key? key,
   }) : super(key: key);
 
   final ValueNotifier<int> notifier;
   final List<CategoryTransaction> categories;
+  final Map<int, double> amounts;
+  final double total;
 
   @override
   Widget build(BuildContext context) {
@@ -47,27 +52,34 @@ class CategoriesPieChart extends StatelessWidget {
               ),
               Column(
                 mainAxisSize: MainAxisSize.min,
-                // TODO: get icon, color and color from category
                 children: [
-                  (notifier.value != -1)
+                  (value != -1)
                       ? Container(
                           padding: const EdgeInsets.all(8.0),
                           decoration: const BoxDecoration(
                             shape: BoxShape.circle,
+                            // TODO: get color from category
                             color: Colors.amber,
                           ),
-                          child: const Icon(Icons.home_rounded),
+                          child: Icon(
+                            stringToIcon(categories[value].symbol) ??
+                                Icons.swap_horiz_rounded,
+                          ),
                         )
                       : const SizedBox(),
                   Text(
-                    "-325.80€",
-                    style: Theme.of(context)
-                        .textTheme
-                        .headlineLarge
-                        ?.copyWith(color: red),
+                    (value != -1)
+                        ? "${amounts[categories[value].id]!.toStringAsFixed(2)} €"
+                        : "${total.toStringAsFixed(2)} €",
+                    style: Theme.of(context).textTheme.headlineLarge?.copyWith(
+                        color: ((value != -1 &&
+                                    amounts[categories[value].id]! > 0) ||
+                                (value == -1 && total > 0))
+                            ? green
+                            : red),
                   ),
-                  (notifier.value != -1)
-                      ? Text(categories[notifier.value].name)
+                  (value != -1)
+                      ? Text(categories[value].name)
                       : const Text("Total"),
                 ],
               ),
@@ -80,15 +92,15 @@ class CategoriesPieChart extends StatelessWidget {
 
   List<PieChartSectionData> showingSections() {
     return List.generate(
-      categories.length,
+      amounts.values.length,
       (i) {
         final isTouched = (i == notifier.value);
 
         final radius = isTouched ? 30.0 : 25.0;
-        // TODO: get the percentage of the total for each category
         return PieChartSectionData(
+          // TODO: get color from category
           color: (i % 2 == 0) ? Colors.red : Colors.blue,
-          value: 360 / categories.length,
+          value: 360 * amounts[categories[i].id]!,
           radius: radius,
           showTitle: false,
         );

--- a/lib/pages/transactions_page/widgets/categories_pie_chart.dart
+++ b/lib/pages/transactions_page/widgets/categories_pie_chart.dart
@@ -1,0 +1,98 @@
+import "package:flutter/material.dart";
+import 'package:fl_chart/fl_chart.dart';
+import 'package:sossoldi/constants/style.dart';
+
+import '../../../model/category_transaction.dart';
+
+class CategoriesPieChart extends StatelessWidget {
+  const CategoriesPieChart({
+    required this.notifier,
+    required this.categories,
+    Key? key,
+  }) : super(key: key);
+
+  final ValueNotifier<int> notifier;
+  final List<CategoryTransaction> categories;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 200,
+      child: ValueListenableBuilder(
+        valueListenable: notifier,
+        builder: (context, value, child) {
+          return Stack(
+            alignment: Alignment.center,
+            children: [
+              PieChart(
+                PieChartData(
+                  startDegreeOffset: -90,
+                  centerSpaceRadius: 70,
+                  sectionsSpace: 0,
+                  borderData: FlBorderData(show: false),
+                  sections: showingSections(),
+                  pieTouchData: PieTouchData(
+                    touchCallback: (FlTouchEvent event, pieTouchResponse) {
+                      // expand category when tapped
+                      if (!event.isInterestedForInteractions ||
+                          pieTouchResponse == null ||
+                          pieTouchResponse.touchedSection == null) {
+                        return;
+                      }
+                      notifier.value =
+                          pieTouchResponse.touchedSection!.touchedSectionIndex;
+                    },
+                  ),
+                ),
+              ),
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                // TODO: get icon, color and color from category
+                children: [
+                  (notifier.value != -1)
+                      ? Container(
+                          padding: const EdgeInsets.all(8.0),
+                          decoration: const BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: Colors.amber,
+                          ),
+                          child: const Icon(Icons.home_rounded),
+                        )
+                      : const SizedBox(),
+                  Text(
+                    "-325.80€",
+                    style: Theme.of(context)
+                        .textTheme
+                        .headlineLarge
+                        ?.copyWith(color: red),
+                  ),
+                  (notifier.value != -1)
+                      ? Text(categories[notifier.value].name)
+                      : const Text("Total"),
+                ],
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  List<PieChartSectionData> showingSections() {
+    return List.generate(
+      categories.length,
+      (i) {
+        final isTouched = (i == notifier.value);
+
+        final radius = isTouched ? 30.0 : 25.0;
+        // TODO: get the percentage of the total for each category
+        return PieChartSectionData(
+          color: (i % 2 == 0) ? Colors.red : Colors.blue,
+          value: 360 / categories.length,
+          radius: radius,
+          showTitle: false,
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/transactions_page/widgets/categories_tab.dart
+++ b/lib/pages/transactions_page/widgets/categories_tab.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 
+import '/constants/style.dart';
+import 'category_list_tile.dart';
+
 class CategoriesTab extends StatelessWidget {
   const CategoriesTab({
     Key? key,
@@ -7,19 +10,22 @@ class CategoriesTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
-      itemCount: 20,
-      itemBuilder: (context, index) {
-        return ListTile(
-          title: Text(
-            "Categorie $index",
-            style: Theme.of(context)
-                .textTheme
-                .bodyText1
-                ?.copyWith(color: Colors.green),
-          ),
-        );
-      },
+    return Container(
+      margin: const EdgeInsets.all(8.0),
+      padding: const EdgeInsets.all(8.0),
+      color: grey3,
+      child: ListView.separated(
+        itemCount: 3,
+        itemBuilder: (context, index) => const CategoryListTile(
+          title: "Casa",
+          amount: -325.90,
+          nTransactions: 2,
+          percent: 70,
+          color: Color(0xFFEBC35F),
+          icon: Icons.home_rounded,
+        ),
+        separatorBuilder: (context, index) => const SizedBox(height: 8.0),
+      ),
     );
   }
 }

--- a/lib/pages/transactions_page/widgets/categories_tab.dart
+++ b/lib/pages/transactions_page/widgets/categories_tab.dart
@@ -7,6 +7,8 @@ import '../../../constants/style.dart';
 import 'categories_pie_chart.dart';
 import 'category_list_tile.dart';
 
+enum Type { income, expense }
+
 class CategoriesTab extends ConsumerStatefulWidget {
   const CategoriesTab({
     Key? key,
@@ -17,7 +19,8 @@ class CategoriesTab extends ConsumerStatefulWidget {
 }
 
 class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
-  final notifier = ValueNotifier<int>(-1);
+  final selectedCategory = ValueNotifier<int>(-1);
+  final transactionType = ValueNotifier<int>(Type.income.index);
 
   @override
   Widget build(BuildContext context) {
@@ -29,42 +32,17 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
       color: grey3,
       child: ListView(
         children: [
-          // TODO: extract to a separate widget
-          // switch between income and expenses
-          Container(
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: [
-                GestureDetector(
-                  onTap: () {},
-                  child: Container(
-                    decoration: const BoxDecoration(
-                      color: blue3,
-                      borderRadius: BorderRadius.all(Radius.circular(5)),
-                    ),
-                    padding: const EdgeInsets.symmetric(
-                      vertical: 4.0,
-                      horizontal: 12.0,
-                    ),
-                    child: Text(
-                      "Income",
-                      style: Theme.of(context)
-                          .textTheme
-                          .bodyLarge
-                          ?.copyWith(color: white),
-                    ),
-                  ),
-                ),
-                Container(child: Text("Expenses")),
-              ],
-            ),
+          TransactionTypeButton(
+            width: MediaQuery.of(context).size.width,
+            notifier: transactionType,
           ),
+          const SizedBox(height: 16),
           CategoriesPieChart(
-            notifier: notifier,
+            notifier: selectedCategory,
             // will it rebuild the child on change?
             categories: categoriesList.value ?? [],
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: 16),
           SizedBox(
             height: 400,
             child: ListView.builder(
@@ -78,12 +56,106 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
                 percent: 70,
                 color: const Color(0xFFEBC35F),
                 icon: Icons.home_rounded,
-                notifier: notifier,
+                notifier: selectedCategory,
                 index: index,
               ),
             ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// Switch between income and expenses
+class TransactionTypeButton extends StatelessWidget {
+  const TransactionTypeButton({
+    super.key,
+    required this.width,
+    required this.notifier,
+  });
+
+  final ValueNotifier<int> notifier;
+  final double width;
+  final double height = 28.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: const BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.all(
+          Radius.circular(5.0),
+        ),
+      ),
+      child: ValueListenableBuilder(
+        valueListenable: notifier,
+        builder: (context, value, child) {
+          return Stack(
+            children: [
+              AnimatedAlign(
+                alignment: Alignment(
+                  (notifier.value == Type.income.index) ? -1 : 1,
+                  0,
+                ),
+                curve: Curves.decelerate,
+                duration: const Duration(milliseconds: 180),
+                child: Container(
+                  width: width * 0.5,
+                  height: height,
+                  decoration: const BoxDecoration(
+                    color: blue5,
+                    borderRadius: BorderRadius.all(
+                      Radius.circular(5.0),
+                    ),
+                  ),
+                ),
+              ),
+              GestureDetector(
+                onTap: () {
+                  notifier.value = Type.income.index;
+                },
+                child: Align(
+                  alignment: const Alignment(-1, 0),
+                  child: Container(
+                    width: width * 0.5,
+                    color: Colors.transparent,
+                    alignment: Alignment.center,
+                    child: Text(
+                      "Income",
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: (notifier.value == Type.income.index)
+                              ? white
+                              : blue2),
+                    ),
+                  ),
+                ),
+              ),
+              GestureDetector(
+                onTap: () {
+                  notifier.value = Type.expense.index;
+                },
+                child: Align(
+                  alignment: const Alignment(1, 0),
+                  child: Container(
+                    width: width * 0.5,
+                    color: Colors.transparent,
+                    alignment: Alignment.center,
+                    child: Text(
+                      'Expenses',
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: (notifier.value == Type.expense.index)
+                              ? white
+                              : blue2),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/lib/pages/transactions_page/widgets/categories_tab.dart
+++ b/lib/pages/transactions_page/widgets/categories_tab.dart
@@ -1,30 +1,89 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sossoldi/constants/functions.dart';
 
-import '/constants/style.dart';
+import '../../../providers/categories_provider.dart';
+import '../../../constants/style.dart';
+import 'categories_pie_chart.dart';
 import 'category_list_tile.dart';
 
-class CategoriesTab extends StatelessWidget {
+class CategoriesTab extends ConsumerStatefulWidget {
   const CategoriesTab({
     Key? key,
   }) : super(key: key);
 
   @override
+  ConsumerState<CategoriesTab> createState() => _CategoriesTabState();
+}
+
+class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
+  final notifier = ValueNotifier<int>(-1);
+
+  @override
   Widget build(BuildContext context) {
+    final categoriesList = ref.watch(categoriesProvider);
+
     return Container(
       margin: const EdgeInsets.all(8.0),
       padding: const EdgeInsets.all(8.0),
       color: grey3,
-      child: ListView.separated(
-        itemCount: 3,
-        itemBuilder: (context, index) => const CategoryListTile(
-          title: "Casa",
-          amount: -325.90,
-          nTransactions: 2,
-          percent: 70,
-          color: Color(0xFFEBC35F),
-          icon: Icons.home_rounded,
-        ),
-        separatorBuilder: (context, index) => const SizedBox(height: 8.0),
+      child: ListView(
+        children: [
+          // TODO: extract to a separate widget
+          // switch between income and expenses
+          Container(
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                GestureDetector(
+                  onTap: () {},
+                  child: Container(
+                    decoration: const BoxDecoration(
+                      color: blue3,
+                      borderRadius: BorderRadius.all(Radius.circular(5)),
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                      vertical: 4.0,
+                      horizontal: 12.0,
+                    ),
+                    child: Text(
+                      "Income",
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyLarge
+                          ?.copyWith(color: white),
+                    ),
+                  ),
+                ),
+                Container(child: Text("Expenses")),
+              ],
+            ),
+          ),
+          CategoriesPieChart(
+            notifier: notifier,
+            // will it rebuild the child on change?
+            categories: categoriesList.value ?? [],
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 400,
+            child: ListView.builder(
+              // TODO: implement nested ListView and remove SizedBox
+              physics: const ClampingScrollPhysics(),
+              itemCount: categoriesList.value?.length,
+              itemBuilder: (context, index) => CategoryListTile(
+                title: categoriesList.value?[index].name ?? "",
+                amount: -325.90,
+                nTransactions: 3,
+                percent: 70,
+                color: const Color(0xFFEBC35F),
+                icon: Icons.home_rounded,
+                notifier: notifier,
+                index: index,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/pages/transactions_page/widgets/categories_tab.dart
+++ b/lib/pages/transactions_page/widgets/categories_tab.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:sossoldi/constants/functions.dart';
 
-import '../../../providers/categories_provider.dart';
 import '../../../constants/style.dart';
+import '../../../constants/functions.dart';
+import '../../../model/category_transaction.dart';
+import '../../../providers/categories_provider.dart';
+import '../../../providers/transactions_provider.dart';
 import 'categories_pie_chart.dart';
 import 'category_list_tile.dart';
 
@@ -20,47 +22,141 @@ class CategoriesTab extends ConsumerStatefulWidget {
 
 class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
   final selectedCategory = ValueNotifier<int>(-1);
+
+  /// income or expenses
   final transactionType = ValueNotifier<int>(Type.income.index);
 
   @override
   Widget build(BuildContext context) {
-    final categoriesList = ref.watch(categoriesProvider);
+    // TODO: query only categories with expenses/income during the selected month
+    final categories = ref.watch(categoriesProvider);
+    final transactions = ref.watch(transactionsProvider);
+
+    // create a map to link each categories with a list of its transactions
+    // stored as Map<String, dynamic> to be passed to CategoryListTile
+    Map<int, List<Map<String, dynamic>>> categoryToTransactions = {};
+    Map<int, double> categoryToAmount = {};
+    double total = 0;
+
+    if (transactions.value != null) {
+      for (var t in transactions.value!) {
+        // add transaction to its category
+        int categoryId = t.idCategory!;
+        if (categoryToTransactions.containsKey(categoryId)) {
+          categoryToTransactions[categoryId]?.add({
+            "account": t.idBankAccount.toString(),
+            "amount": t.amount,
+            "category": categoryId.toString(),
+            "title": t.note,
+          });
+        } else {
+          categoryToTransactions.putIfAbsent(
+            categoryId,
+            () => [
+              {
+                "account": t.idBankAccount.toString(),
+                "amount": t.amount,
+                "category": categoryId.toString(),
+                "title": t.note,
+              }
+            ],
+          );
+        }
+
+        // update total amount for the category
+        total += t.amount;
+        if (categoryToAmount.containsKey(categoryId)) {
+          categoryToAmount[categoryId] =
+              categoryToAmount[categoryId]! + t.amount.toDouble();
+        } else {
+          categoryToAmount.putIfAbsent(categoryId, () => t.amount.toDouble());
+        }
+      }
+    }
+
+    // Add missing catogories (with amount 0)
+    // This will be removed when only categories with transactions are queried
+    for (var c in categories.value!) {
+      categoryToAmount.putIfAbsent(c.id!, () => 0);
+    }
 
     return Container(
-      margin: const EdgeInsets.all(8.0),
-      padding: const EdgeInsets.all(8.0),
+      margin: const EdgeInsets.symmetric(horizontal: 8.0),
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
       color: grey3,
       child: ListView(
         children: [
+          const SizedBox(height: 12.0),
           TransactionTypeButton(
             width: MediaQuery.of(context).size.width,
             notifier: transactionType,
           ),
           const SizedBox(height: 16),
-          CategoriesPieChart(
-            notifier: selectedCategory,
-            // will it rebuild the child on change?
-            categories: categoriesList.value ?? [],
-          ),
-          const SizedBox(height: 16),
-          SizedBox(
-            height: 400,
-            child: ListView.builder(
-              // TODO: implement nested ListView and remove SizedBox
-              physics: const ClampingScrollPhysics(),
-              itemCount: categoriesList.value?.length,
-              itemBuilder: (context, index) => CategoryListTile(
-                title: categoriesList.value?[index].name ?? "",
-                amount: -325.90,
-                nTransactions: 3,
-                percent: 70,
-                color: const Color(0xFFEBC35F),
-                icon: Icons.home_rounded,
-                notifier: selectedCategory,
-                index: index,
-              ),
+          categories.when(
+            data: (data) => CategoriesPieChart(
+              notifier: selectedCategory,
+              categories: categories.value!,
+              amounts: categoryToAmount,
+              total: total,
+            ),
+            error: (error, stackTrace) => Center(
+              child: Text(error.toString()),
+            ),
+            loading: () => const Center(
+              child: CircularProgressIndicator(),
             ),
           ),
+          const SizedBox(height: 16),
+          categories.when(
+            data: (data) {
+              return ValueListenableBuilder(
+                valueListenable: selectedCategory,
+                builder: (context, value, child) {
+                  return SizedBox(
+                    // calculate height from the number of categories and transactions
+                    //! it throws RenderFlex overflowed during the closing animation
+                    height: 72.0 * categories.value!.length +
+                        ((value != -1)
+                            ? (categoryToTransactions[
+                                            categories.value![value].id]
+                                        ?.length ??
+                                    0.0) *
+                                70.0
+                            : 0.0),
+                    child: Column(
+                      children: List.generate(
+                        categories.value!.length,
+                        (index) {
+                          CategoryTransaction t = categories.value![index];
+                          return CategoryListTile(
+                            title: t.name,
+                            nTransactions:
+                                categoryToTransactions[t.id]?.length ?? 0,
+                            transactions: categoryToTransactions[t.id] ?? [],
+                            amount: categoryToAmount[t.id] ?? 0,
+                            percent:
+                                (categoryToAmount[t.id] ?? 0) / total * 100,
+                            color: const Color(0xFFEBC35F),
+                            icon: stringToIcon(t.symbol) ??
+                                Icons.swap_horiz_rounded,
+                            notifier: selectedCategory,
+                            index: index,
+                          );
+                        },
+                      ),
+                    ),
+                  );
+                },
+              );
+            },
+            error: (error, stackTrace) => Center(
+              child: Text(error.toString()),
+            ),
+            loading: () => const Center(
+              child: CircularProgressIndicator(),
+            ),
+          ),
+          const SizedBox(height: 12.0),
         ],
       ),
     );

--- a/lib/pages/transactions_page/widgets/category_list_tile.dart
+++ b/lib/pages/transactions_page/widgets/category_list_tile.dart
@@ -1,8 +1,8 @@
 import "package:flutter/material.dart";
 
-import '/constants/style.dart';
+import '../../../constants/style.dart';
 
-class CategoryListTile extends StatefulWidget {
+class CategoryListTile extends StatelessWidget {
   const CategoryListTile({
     super.key,
     required this.title,
@@ -11,6 +11,8 @@ class CategoryListTile extends StatefulWidget {
     required this.percent,
     required this.color,
     required this.icon,
+    required this.notifier,
+    required this.index,
   });
 
   final String title;
@@ -19,102 +21,195 @@ class CategoryListTile extends StatefulWidget {
   final double percent;
   final Color color;
   final IconData icon;
+  final ValueNotifier<int> notifier;
+  final int index;
 
-  @override
-  State<CategoryListTile> createState() => _CategoryListTileState();
-}
-
-class _CategoryListTileState extends State<CategoryListTile> {
-  bool _isExpanded = false;
 
   /// Toogle the box to expand or collapse
   void _toogleExpand() {
-    setState(() {
-      _isExpanded = !_isExpanded;
-    });
+    if (notifier.value == index) {
+      notifier.value = -1;
+    } else {
+      notifier.value = index;
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: <Widget>[
-        GestureDetector(
-          onTap: _toogleExpand,
-          child: Container(
-            color: widget.color.withAlpha(90),
-            padding: const EdgeInsets.symmetric(
-              horizontal: 8.0,
-              vertical: 16.0,
+    return ValueListenableBuilder(
+      valueListenable: notifier,
+      builder: (context, value, child) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            GestureDetector(
+              onTap: _toogleExpand,
+              child: Container(
+                color: color.withAlpha(90),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 8.0,
+                  vertical: 16.0,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.max,
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(8.0),
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: color,
+                      ),
+                      child: Icon(icon),
+                    ),
+                    const SizedBox(width: 8.0),
+                    Expanded(
+                      child: Column(
+                        children: [
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(
+                                title,
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
+                              Text(
+                                "$amount €",
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .bodyLarge
+                                    ?.copyWith(
+                                        color: (amount > 0) ? green : red),
+                              ),
+                            ],
+                          ),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: [
+                              Text(
+                                "$nTransactions transactions",
+                                style: Theme.of(context).textTheme.labelLarge,
+                              ),
+                              Text(
+                                "$percent%",
+                                style: Theme.of(context).textTheme.labelLarge,
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 8.0),
+                    Icon(
+                      (notifier.value == index)
+                          ? Icons.expand_more
+                          : Icons.chevron_right,
+                    ),
+                  ],
+                ),
+              ),
             ),
-            child: Row(
-              mainAxisSize: MainAxisSize.max,
+            ExpandedSection(
+              expand: notifier.value == index,
+              // TODO: add transactions under category
+              child: Container(
+                color: white,
+                height: 70.0 * nTransactions,
+                child: Column(
+                  mainAxisSize: MainAxisSize.max,
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: List.generate(
+                    2 * nTransactions - 1,
+                    (index) {
+                      if (index % 2 == 0) {
+                        return const TransactionRow(
+                          account: "Buddybank",
+                          amount: -25.80,
+                          category: "Casa",
+                          title: "Spesa",
+                        );
+                      } else {
+                        return const Divider(
+                          height: 1,
+                          thickness: 1,
+                          indent: 15,
+                          endIndent: 15,
+                        );
+                      }
+                    },
+                  ),
+                ),
+              ),
+            )
+          ],
+        );
+      }
+    );
+  }
+}
+
+class TransactionRow extends StatelessWidget {
+  const TransactionRow({
+    super.key,
+    required this.title,
+    required this.category,
+    required this.amount,
+    required this.account,
+  });
+
+  final String title;
+  final String category;
+  final double amount;
+  final String account;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: 8.0,
+        vertical: 16.0,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          const SizedBox(width: 48.0),
+          Expanded(
+            child: Column(
               children: [
-                Container(
-                  padding: const EdgeInsets.all(8.0),
-                  decoration: BoxDecoration(
-                    shape: BoxShape.circle,
-                    color: widget.color,
-                  ),
-                  child: Icon(widget.icon),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    Text(
+                      "$amount €",
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyLarge
+                          ?.copyWith(color: (amount > 0) ? green : red),
+                    ),
+                  ],
                 ),
-                const SizedBox(width: 8.0),
-                Expanded(
-                  child: Column(
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(
-                            widget.title,
-                            style: Theme.of(context).textTheme.titleMedium,
-                          ),
-                          Text(
-                            "${widget.amount} €",
-                            style: Theme.of(context)
-                                .textTheme
-                                .bodyLarge
-                                ?.copyWith(
-                                    color: (widget.amount > 0) ? green : red),
-                          ),
-                        ],
-                      ),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        children: [
-                          Text(
-                            "${widget.nTransactions} transactions",
-                            style: Theme.of(context).textTheme.labelLarge,
-                          ),
-                          Text(
-                            "${widget.percent}%",
-                            style: Theme.of(context).textTheme.labelLarge,
-                          ),
-                        ],
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(width: 8.0),
-                Icon(
-                  (_isExpanded) ? Icons.expand_more : Icons.chevron_right,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      category.toUpperCase(),
+                      style: Theme.of(context).textTheme.labelLarge,
+                    ),
+                    Text(
+                      account.toUpperCase(),
+                      style: Theme.of(context).textTheme.labelLarge,
+                    ),
+                  ],
                 ),
               ],
             ),
           ),
-        ),
-        ExpandedSection(
-          expand: _isExpanded,
-          // TODO: add transactions under category
-          child: Container(
-            width: double.infinity,
-            height: 100,
-            color: Colors.red,
-            padding: EdgeInsets.all(25.0),
-            child: Text('Work in progress...'),
-          ),
-        )
-      ],
+          const SizedBox(width: 8.0),
+        ],
+      ),
     );
   }
 }

--- a/lib/pages/transactions_page/widgets/category_list_tile.dart
+++ b/lib/pages/transactions_page/widgets/category_list_tile.dart
@@ -8,6 +8,7 @@ class CategoryListTile extends StatelessWidget {
     required this.title,
     required this.amount,
     required this.nTransactions,
+    required this.transactions,
     required this.percent,
     required this.color,
     required this.icon,
@@ -18,12 +19,12 @@ class CategoryListTile extends StatelessWidget {
   final String title;
   final double amount;
   final int nTransactions;
+  final List<Map<String, dynamic>> transactions;
   final double percent;
   final Color color;
   final IconData icon;
   final ValueNotifier<int> notifier;
   final int index;
-
 
   /// Toogle the box to expand or collapse
   void _toogleExpand() {
@@ -73,7 +74,7 @@ class CategoryListTile extends StatelessWidget {
                                 style: Theme.of(context).textTheme.titleMedium,
                               ),
                               Text(
-                                "$amount €",
+                                "${amount.toStringAsFixed(2)} €",
                                 style: Theme.of(context)
                                     .textTheme
                                     .bodyLarge
@@ -90,7 +91,7 @@ class CategoryListTile extends StatelessWidget {
                                 style: Theme.of(context).textTheme.labelLarge,
                               ),
                               Text(
-                                "$percent%",
+                                "${percent.toStringAsFixed(2)}%",
                                 style: Theme.of(context).textTheme.labelLarge,
                               ),
                             ],
@@ -110,39 +111,40 @@ class CategoryListTile extends StatelessWidget {
             ),
             ExpandedSection(
               expand: notifier.value == index,
-              // TODO: add transactions under category
               child: Container(
                 color: white,
                 height: 70.0 * nTransactions,
                 child: Column(
                   mainAxisSize: MainAxisSize.max,
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: List.generate(
-                    2 * nTransactions - 1,
-                    (index) {
-                      if (index % 2 == 0) {
-                        return const TransactionRow(
-                          account: "Buddybank",
-                          amount: -25.80,
-                          category: "Casa",
-                          title: "Spesa",
-                        );
-                      } else {
-                        return const Divider(
-                          height: 1,
-                          thickness: 1,
-                          indent: 15,
-                          endIndent: 15,
-                        );
-                      }
-                    },
-                  ),
+                  children: (nTransactions > 0)
+                      ? List.generate(
+                          2 * nTransactions - 1,
+                          (i) {
+                            if (i % 2 == 0) {
+                              return TransactionRow(
+                                account: transactions[i ~/ 2]["account"],
+                                amount: transactions[i ~/ 2]["amount"],
+                                category: transactions[i ~/ 2]["category"],
+                                title: transactions[i ~/ 2]["title"],
+                              );
+                            } else {
+                              return const Divider(
+                                height: 1,
+                                thickness: 1,
+                                indent: 15,
+                                endIndent: 15,
+                              );
+                            }
+                          },
+                        )
+                      : [],
                 ),
               ),
             )
           ],
         );
-      }
+      },
     );
   }
 }
@@ -183,7 +185,7 @@ class TransactionRow extends StatelessWidget {
                       style: Theme.of(context).textTheme.titleMedium,
                     ),
                     Text(
-                      "$amount €",
+                      "${amount.toStringAsFixed(2)} €",
                       style: Theme.of(context)
                           .textTheme
                           .bodyLarge

--- a/lib/pages/transactions_page/widgets/category_list_tile.dart
+++ b/lib/pages/transactions_page/widgets/category_list_tile.dart
@@ -1,0 +1,187 @@
+import "package:flutter/material.dart";
+
+import '/constants/style.dart';
+
+class CategoryListTile extends StatefulWidget {
+  const CategoryListTile({
+    super.key,
+    required this.title,
+    required this.amount,
+    required this.nTransactions,
+    required this.percent,
+    required this.color,
+    required this.icon,
+  });
+
+  final String title;
+  final double amount;
+  final int nTransactions;
+  final double percent;
+  final Color color;
+  final IconData icon;
+
+  @override
+  State<CategoryListTile> createState() => _CategoryListTileState();
+}
+
+class _CategoryListTileState extends State<CategoryListTile> {
+  bool _isExpanded = false;
+
+  /// Toogle the box to expand or collapse
+  void _toogleExpand() {
+    setState(() {
+      _isExpanded = !_isExpanded;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        GestureDetector(
+          onTap: _toogleExpand,
+          child: Container(
+            color: widget.color.withAlpha(90),
+            padding: const EdgeInsets.symmetric(
+              horizontal: 8.0,
+              vertical: 16.0,
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.max,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(8.0),
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: widget.color,
+                  ),
+                  child: Icon(widget.icon),
+                ),
+                const SizedBox(width: 8.0),
+                Expanded(
+                  child: Column(
+                    children: [
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            widget.title,
+                            style: Theme.of(context).textTheme.titleMedium,
+                          ),
+                          Text(
+                            "${widget.amount} €",
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyLarge
+                                ?.copyWith(
+                                    color: (widget.amount > 0) ? green : red),
+                          ),
+                        ],
+                      ),
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            "${widget.nTransactions} transactions",
+                            style: Theme.of(context).textTheme.labelLarge,
+                          ),
+                          Text(
+                            "${widget.percent}%",
+                            style: Theme.of(context).textTheme.labelLarge,
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8.0),
+                Icon(
+                  (_isExpanded) ? Icons.expand_more : Icons.chevron_right,
+                ),
+              ],
+            ),
+          ),
+        ),
+        ExpandedSection(
+          expand: _isExpanded,
+          // TODO: add transactions under category
+          child: Container(
+            width: double.infinity,
+            height: 100,
+            color: Colors.red,
+            padding: EdgeInsets.all(25.0),
+            child: Text('Work in progress...'),
+          ),
+        )
+      ],
+    );
+  }
+}
+
+class ExpandedSection extends StatefulWidget {
+  const ExpandedSection({
+    super.key,
+    this.expand = false,
+    required this.child,
+  });
+
+  final Widget child;
+  final bool expand;
+
+  @override
+  State<ExpandedSection> createState() => _ExpandedSectionState();
+}
+
+class _ExpandedSectionState extends State<ExpandedSection>
+    with SingleTickerProviderStateMixin {
+  late AnimationController expandController;
+  late Animation<double> animation;
+
+  @override
+  void initState() {
+    super.initState();
+    prepareAnimations();
+  }
+
+  ///Setting up the animation
+  void prepareAnimations() {
+    expandController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 300),
+    );
+    Animation<double> curve = CurvedAnimation(
+      parent: expandController,
+      curve: Curves.fastOutSlowIn,
+    );
+    animation = Tween(begin: 0.0, end: 1.0).animate(curve)
+      ..addListener(() {
+        setState(() {});
+      });
+  }
+
+  @override
+  void didUpdateWidget(ExpandedSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.expand) {
+      expandController.forward();
+    } else {
+      expandController.reverse();
+    }
+  }
+
+  @override
+  void dispose() {
+    expandController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizeTransition(
+      axisAlignment: 1.0,
+      sizeFactor: animation,
+      child: widget.child,
+    );
+  }
+}

--- a/lib/pages/transactions_page/widgets/list_tab.dart
+++ b/lib/pages/transactions_page/widgets/list_tab.dart
@@ -1,4 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../constants/style.dart';
+import '../../../model/transaction.dart';
+import '../../../pages/transactions_page/widgets/transaction_list_tile.dart';
 
 class ListTab extends StatelessWidget {
   const ListTab({
@@ -7,19 +12,147 @@ class ListTab extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
-      itemCount: 20,
-      itemBuilder: (context, index) {
-        return ListTile(
-          title: Text(
-            "Elenco $index",
+    // TODO: get list of transactions from database
+    List<Transaction> transactions = [
+      Transaction(
+        id: 0,
+        recurring: false,
+        date: DateTime.now(),
+        amount: 300,
+        type: Type.income,
+        idBankAccount: 0,
+        idCategory: 0,
+      ),
+      Transaction(
+        id: 1,
+        recurring: false,
+        date: DateTime.now(),
+        amount: 65,
+        type: Type.income,
+        idBankAccount: 0,
+        idCategory: 0,
+      ),
+      Transaction(
+        id: 2,
+        recurring: false,
+        date: DateTime.now().subtract(Duration(days: 1)),
+        amount: 34,
+        type: Type.income,
+        idBankAccount: 0,
+        idCategory: 0,
+      ),
+      Transaction(
+        id: 3,
+        recurring: false,
+        date: DateTime.now().subtract(Duration(days: 3)),
+        amount: -304,
+        type: Type.income,
+        idBankAccount: 0,
+        idCategory: 0,
+      ),
+      Transaction(
+        id: 4,
+        recurring: false,
+        date: DateTime.now().subtract(Duration(days: 3)),
+        amount: 231,
+        type: Type.income,
+        idBankAccount: 0,
+        idCategory: 0,
+      ),
+    ];
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 8.0),
+      padding: const EdgeInsets.symmetric(horizontal: 12.0),
+      color: grey3,
+      child: ListView.separated(
+        itemCount: transactions.length + 1,
+        itemBuilder: (context, i) {
+          if (i == 0) {
+            return DateSeparator(
+              transaction: transactions[i],
+              total: 123,
+            );
+          } else {
+            return TransactionListTile(
+              title:
+                  "${transactions[i - 1].date.day}-${transactions[i - 1].date.month}",
+              amount: transactions[i - 1].amount.toDouble(),
+              account: "Account",
+              category: "Category",
+              color: Colors.red,
+              icon: Icons.home,
+            );
+          }
+        },
+        separatorBuilder: (context, i) {
+          if (i == 0) {
+            return const SizedBox(height: 0);
+          } else {
+            if (!transactions[i - 1].date.isSameDate(transactions[i].date)) {
+              return DateSeparator(
+                transaction: transactions[i],
+                total: 123,
+              );
+            } else {
+              return const Divider(
+                height: 0,
+                thickness: 1,
+                endIndent: 10,
+                indent: 10,
+              );
+            }
+          }
+        },
+      ),
+    );
+  }
+}
+
+class DateSeparator extends StatelessWidget {
+  const DateSeparator({
+    Key? key,
+    required this.transaction,
+    required this.total,
+  }) : super(key: key);
+
+  final Transaction transaction;
+  final double total;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 12.0, bottom: 6.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            transaction.date.formatDate(),
+            style:
+                Theme.of(context).textTheme.bodySmall?.copyWith(color: blue1),
+          ),
+          Text(
+            "$total €",
             style: Theme.of(context)
                 .textTheme
-                .bodyText1
-                ?.copyWith(color: Colors.blue),
-          ),
-        );
-      },
+                .bodyLarge
+                ?.copyWith(color: (total > 0) ? green : red),
+          )
+        ],
+      ),
     );
+  }
+}
+
+const String dateFormatter = 'MMMM d, EEEE';
+
+extension DateHelper on DateTime {
+  String formatDate() {
+    final formatter = DateFormat(dateFormatter);
+    return formatter.format(this);
+  }
+
+  bool isSameDate(DateTime other) {
+    return year == other.year && month == other.month && day == other.day;
   }
 }

--- a/lib/pages/transactions_page/widgets/transaction_list_tile.dart
+++ b/lib/pages/transactions_page/widgets/transaction_list_tile.dart
@@ -1,0 +1,82 @@
+import "package:flutter/material.dart";
+
+import '../../../constants/style.dart';
+
+class TransactionListTile extends StatelessWidget {
+  const TransactionListTile({
+    Key? key,
+    required this.title,
+    required this.amount,
+    required this.color,
+    required this.category,
+    required this.icon,
+    required this.account,
+  }) : super(key: key);
+
+  final String title;
+  final double amount;
+  final Color color;
+  final String category;
+  final IconData icon;
+  final String account;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: color.withAlpha(90),
+      padding: const EdgeInsets.symmetric(
+        horizontal: 8.0,
+        vertical: 16.0,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          Container(
+            padding: const EdgeInsets.all(8.0),
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: color,
+            ),
+            child: Icon(icon),
+          ),
+          const SizedBox(width: 8.0),
+          Expanded(
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      title,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    Text(
+                      "$amount €",
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyLarge
+                          ?.copyWith(color: (amount > 0) ? green : red),
+                    ),
+                  ],
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      category.toUpperCase(),
+                      style: Theme.of(context).textTheme.labelMedium,
+                    ),
+                    Text(
+                      account.toUpperCase(),
+                      style: Theme.of(context).textTheme.labelMedium,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/transactions_page/widgets/transaction_list_tile.dart
+++ b/lib/pages/transactions_page/widgets/transaction_list_tile.dart
@@ -23,10 +23,10 @@ class TransactionListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: color.withAlpha(90),
+      color: Colors.white,
       padding: const EdgeInsets.symmetric(
         horizontal: 8.0,
-        vertical: 16.0,
+        vertical: 12.0,
       ),
       child: Row(
         mainAxisSize: MainAxisSize.max,

--- a/lib/pages/transactions_page/widgets/transaction_list_tile.dart
+++ b/lib/pages/transactions_page/widgets/transaction_list_tile.dart
@@ -51,7 +51,7 @@ class TransactionListTile extends StatelessWidget {
                       style: Theme.of(context).textTheme.titleMedium,
                     ),
                     Text(
-                      "$amount €",
+                      "${amount.toStringAsFixed(2)} €",
                       style: Theme.of(context)
                           .textTheme
                           .bodyLarge


### PR DESCRIPTION
I improved the List and Categories tabs. Here are two screenshots of how they look now.
<p float="left">
 <img src="https://user-images.githubusercontent.com/69045457/230786745-e3cd11fd-7edc-456c-8fae-bd6da3b5171c.png" width=40% />
  <img src="https://user-images.githubusercontent.com/69045457/230786726-a192b749-e491-4e33-b082-ddb05c65d122.png" width=40% /> 
</p>

Currently, all transactions are queried from the database regardless of their date. We should query _only the ones in the selected time frame_. Also, the totals for the day and for each category are calculated in the build method of the widgets, which is not ideal. It might be better to retrieve them directly from the database with a designated query. The same goes for the groupings of transactions in their categories in the "Categories" tab.

The list of expandable categories in the "Categories" tab is wrapped in a `Sizebox` whose size is calculated every time a category is expanded. While a category gets collapsed, a `RenderFlex overflowed` is sometimes thrown, because the new size is computed before the end of the animation. After the animation is over, everything is fine.
If you can think of a better solution, please tell me.

## What's missing
- bank account and category of the transaction in the "Categories" tab are shown as numbers instead of names
- colors of the categories for icons and pie chart (still missing from database)
- more specific queries and more efficient calculation of totals
