### PR TITLE
Overflow fixed in the transaction section

### DIFF
--- a/lib/pages/transactions_page/widgets/categories_tab.dart
+++ b/lib/pages/transactions_page/widgets/categories_tab.dart
@@ -117,7 +117,7 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
                                     0.0) *
                                 70.0
                             : 0.0),
-                    child: Column(
+                    child: Wrap(
                       children: List.generate(
                         categories.value!.length,
                         (index) {


### PR DESCRIPTION
[categories tab] Subcategories has overflowed text when opened/closed (#103) fixed