### PR TITLE
Fixed SelectById() old query

### DIFF
--- a/lib/model/transaction.dart
+++ b/lib/model/transaction.dart
@@ -194,8 +194,25 @@ class TransactionMethods extends SossoldiDatabase {
 
   Future<Transaction> selectById(int id) async {
     final db = await database;
-    final maps = await db.rawQuery('SELECT t.*, c.${CategoryTransactionFields.name} as ${TransactionFields.categoryName}, c.${CategoryTransactionFields.color} as ${TransactionFields.categoryColor}, c.${CategoryTransactionFields.symbol} as ${TransactionFields.categorySymbol}, b1.${BankAccountFields.name} as ${TransactionFields.bankAccountName}, b2.${BankAccountFields.name} as ${TransactionFields.bankAccountTransferName} FROM $transactionTable as t LEFT JOIN $categoryTransactionTable as c ON t.${TransactionFields.idCategory} = c.${CategoryTransactionFields.id} LEFT JOIN $bankAccountTable as b1 ON t.${TransactionFields.idBankAccount} = b1.${BankAccountFields.id} LEFT JOIN $bankAccountTable as b2 ON t.${TransactionFields.idBankAccountTransfer} = b2.${BankAccountFields.id} WHERE t.${TransactionFields.id} = ?', [id]);
-
+    final maps = await db.rawQuery('''
+      SELECT t.*, 
+        c.${CategoryTransactionFields.name} as ${TransactionFields.categoryName}, 
+        c.${CategoryTransactionFields.color} as ${TransactionFields.categoryColor}, 
+        c.${CategoryTransactionFields.symbol} as ${TransactionFields.categorySymbol}, 
+        b1.${BankAccountFields.name} as ${TransactionFields.bankAccountName}, 
+        b2.${BankAccountFields.name} as ${TransactionFields.bankAccountTransferName} 
+      FROM 
+        '$transactionTable' as t 
+      LEFT JOIN 
+        $categoryTransactionTable as c ON t.${TransactionFields.idCategory} = c.${CategoryTransactionFields.id} 
+      LEFT JOIN 
+        $bankAccountTable as b1 ON t.${TransactionFields.idBankAccount} = b1.${BankAccountFields.id} 
+      LEFT JOIN 
+        $bankAccountTable as b2 ON t.${TransactionFields.idBankAccountTransfer} = b2.${BankAccountFields.id} 
+      WHERE 
+        t.${TransactionFields.id} = ?
+    ''', [id]);
+    
     if (maps.isNotEmpty) {
       return Transaction.fromJson(maps.first);
     } else {


### PR DESCRIPTION
Addressing issue #151.

I just added quotes around `'$transactionTable'` since `transaction` is a reserved keyword in SQL. 