### PR TITLE
Fix: text instead of ids in transactions page

### DIFF
--- a/lib/pages/transactions_page/widgets/account_list_tile.dart
+++ b/lib/pages/transactions_page/widgets/account_list_tile.dart
@@ -1,7 +1,9 @@
 import "package:flutter/material.dart";
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../constants/functions.dart';
 import '../../../constants/style.dart';
+import '../../../model/transaction.dart';
 import '../../../providers/currency_provider.dart';
 import 'accounts_tab.dart';
 
@@ -21,7 +23,7 @@ class AccountListTile extends ConsumerWidget {
   final String title;
   final double amount;
   final int nTransactions;
-  final List<Map<String, dynamic>> transactions;
+  final List<Transaction> transactions;
   final double percent;
   final Color color;
   final IconData icon;
@@ -137,13 +139,13 @@ class AccountListTile extends ConsumerWidget {
   }
 }
 
-class TransactionRow extends ConsumerWidget {
+class TransactionRow extends ConsumerWidget with Functions {
   const TransactionRow({
     super.key,
     required this.transaction,
   });
 
-  final Map<String, dynamic> transaction;
+  final Transaction transaction;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -164,15 +166,15 @@ class TransactionRow extends ConsumerWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                      transaction['title'],
+                      transaction.note ?? "",
                       style: Theme.of(context).textTheme.titleMedium,
                     ),
                     Text(
-                      "${transaction['amount'].toStringAsFixed(2)} ${currencyState.selectedCurrency.symbol}",
+                      "${numToCurrency(transaction.amount)} ${currencyState.selectedCurrency.symbol}",
                       style: Theme.of(context)
                           .textTheme
                           .bodyLarge
-                          ?.copyWith(color: (transaction['amount'] > 0) ? green : red),
+                          ?.copyWith(color: (transaction.amount > 0) ? green : red),
                     ),
                   ],
                 ),
@@ -180,11 +182,11 @@ class TransactionRow extends ConsumerWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                      transaction['category'].toUpperCase(),
+                      transaction.categoryName?.toUpperCase() ?? "",
                       style: Theme.of(context).textTheme.labelLarge,
                     ),
                     Text(
-                      transaction['account'].toUpperCase(),
+                      transaction.bankAccountName?.toUpperCase() ?? "",
                       style: Theme.of(context).textTheme.labelLarge,
                     ),
                   ],

--- a/lib/pages/transactions_page/widgets/accounts_tab.dart
+++ b/lib/pages/transactions_page/widgets/accounts_tab.dart
@@ -32,24 +32,18 @@ class _AccountsTabState extends ConsumerState<AccountsTab> with Functions {
 
     // create a map to link each accounts with a list of its transactions
     // stored as Map<String, dynamic> to be passed to AccountListTile
-    Map<int, List<Map<String, dynamic>>> accountToTransactionsIncome = {},
+    Map<int, List<Transaction>> accountToTransactionsIncome = {},
         accountToTransactionsExpense = {};
     Map<int, double> accountToAmountIncome = {}, accountToAmountExpense = {};
     double totalIncome = 0, totalExpense = 0;
 
     for (Transaction transaction in transactions.value ?? []) {
       final accountId = transaction.idBankAccount;
-      final updateValue = {
-        "account": transaction.idBankAccount.toString(),
-        "amount": transaction.amount,
-        "category": accountId.toString(),
-        "title": transaction.note,
-      };
       if (transaction.type == TransactionType.income) {
         if (accountToTransactionsIncome.containsKey(accountId)) {
-          accountToTransactionsIncome[accountId]?.add(updateValue);
+          accountToTransactionsIncome[accountId]?.add(transaction);
         } else {
-          accountToTransactionsIncome.putIfAbsent(accountId, () => [updateValue]);
+          accountToTransactionsIncome.putIfAbsent(accountId, () => [transaction]);
         }
 
         // update total amount for the account
@@ -62,9 +56,9 @@ class _AccountsTabState extends ConsumerState<AccountsTab> with Functions {
         }
       } else if (transaction.type == TransactionType.expense) {
         if (accountToTransactionsExpense.containsKey(accountId)) {
-          accountToTransactionsExpense[accountId]?.add(updateValue);
+          accountToTransactionsExpense[accountId]?.add(transaction);
         } else {
-          accountToTransactionsExpense.putIfAbsent(accountId, () => [updateValue]);
+          accountToTransactionsExpense.putIfAbsent(accountId, () => [transaction]);
         }
 
         // update total amount for the account

--- a/lib/pages/transactions_page/widgets/categories_tab.dart
+++ b/lib/pages/transactions_page/widgets/categories_tab.dart
@@ -30,8 +30,8 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
     final transactionType = ref.watch(selectedTransactionTypeProvider);
 
     // create a map to link each categories with a list of its transactions
-    // stored as Map<String, dynamic> to be passed to CategoryListTile
-    Map<int, List<Map<String, dynamic>>> categoryToTransactionsIncome = {},
+    // stored as Transaction to be passed to CategoryListTile
+    Map<int, List<Transaction>> categoryToTransactionsIncome = {},
         categoryToTransactionsExpense = {};
     Map<int, double> categoryToAmountIncome = {}, categoryToAmountExpense = {};
     double totalIncome = 0, totalExpense = 0;
@@ -39,17 +39,11 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
     for (Transaction transaction in transactions.value ?? []) {
       final categoryId = transaction.idCategory;
       if (categoryId != null) {
-        final updateValue = {
-          "account": transaction.idBankAccount.toString(),
-          "amount": transaction.amount,
-          "category": categoryId.toString(),
-          "title": transaction.note,
-        };
         if (transaction.type == TransactionType.income) {
           if (categoryToTransactionsIncome.containsKey(categoryId)) {
-            categoryToTransactionsIncome[categoryId]?.add(updateValue);
+            categoryToTransactionsIncome[categoryId]?.add(transaction);
           } else {
-            categoryToTransactionsIncome.putIfAbsent(categoryId, () => [updateValue]);
+            categoryToTransactionsIncome.putIfAbsent(categoryId, () => [transaction]);
           }
 
           // update total amount for the category
@@ -62,9 +56,9 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
           }
         } else if (transaction.type == TransactionType.expense) {
           if (categoryToTransactionsExpense.containsKey(categoryId)) {
-            categoryToTransactionsExpense[categoryId]?.add(updateValue);
+            categoryToTransactionsExpense[categoryId]?.add(transaction);
           } else {
-            categoryToTransactionsExpense.putIfAbsent(categoryId, () => [updateValue]);
+            categoryToTransactionsExpense.putIfAbsent(categoryId, () => [transaction]);
           }
 
           // update total amount for the category

--- a/lib/pages/transactions_page/widgets/category_list_tile.dart
+++ b/lib/pages/transactions_page/widgets/category_list_tile.dart
@@ -2,8 +2,10 @@ import "package:flutter/material.dart";
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../constants/constants.dart';
+import '../../../constants/functions.dart';
 import '../../../constants/style.dart';
 import '../../../model/category_transaction.dart';
+import '../../../model/transaction.dart';
 import '../../../providers/currency_provider.dart';
 import 'categories_tab.dart';
 
@@ -19,7 +21,7 @@ class CategoryListTile extends ConsumerWidget {
 
   final CategoryTransaction category;
   final double amount;
-  final List<Map<String, dynamic>> transactions;
+  final List<Transaction> transactions;
   final double percent;
   final int index;
 
@@ -134,13 +136,13 @@ class CategoryListTile extends ConsumerWidget {
   }
 }
 
-class TransactionRow extends ConsumerWidget {
+class TransactionRow extends ConsumerWidget with Functions {
   const TransactionRow({
     super.key,
     required this.transaction,
   });
 
-  final Map<String, dynamic> transaction;
+  final Transaction transaction;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -161,15 +163,15 @@ class TransactionRow extends ConsumerWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                      transaction['title'],
+                      transaction.note ?? "",
                       style: Theme.of(context).textTheme.titleMedium,
                     ),
                     Text(
-                      "${transaction['amount'].toStringAsFixed(2)} ${currencyState.selectedCurrency.symbol}",
+                      "${numToCurrency(transaction.amount)} ${currencyState.selectedCurrency.symbol}",
                       style: Theme.of(context)
                           .textTheme
                           .bodyLarge
-                          ?.copyWith(color: (transaction['amount'] > 0) ? green : red),
+                          ?.copyWith(color: (transaction.amount > 0) ? green : red),
                     ),
                   ],
                 ),
@@ -177,11 +179,11 @@ class TransactionRow extends ConsumerWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                      transaction['category'].toUpperCase(),
+                      transaction.categoryName?.toUpperCase() ?? "",
                       style: Theme.of(context).textTheme.labelLarge,
                     ),
                     Text(
-                      transaction['account'].toUpperCase(),
+                      transaction.bankAccountName?.toUpperCase() ?? "",
                       style: Theme.of(context).textTheme.labelLarge,
                     ),
                   ],


### PR DESCRIPTION
The Categories and Accounts page in Transactions now show correctly the category and account name of each transaction instead of their ids.