### PR TITLE
Fix for Account Exclusion Issue Due to Recurring Transactions

### DIFF
--- a/lib/model/bank_account.dart
+++ b/lib/model/bank_account.dart
@@ -149,8 +149,8 @@ class BankAccountMethods extends SossoldiDatabase {
     final db = await database;
 
     final orderByASC = '${BankAccountFields.createdAt} ASC';
-    final where =
-        '${BankAccountFields.active} = 1 AND (${TransactionFields.recurring} = 0 OR ${TransactionFields.recurring} is NULL)';
+    final where = '${BankAccountFields.active} = 1 ';
+    final recurringFilter = '(t.${TransactionFields.recurring} = 0 OR t.${TransactionFields.recurring} IS NULL)';
 
     final result = await db.rawQuery('''
       SELECT b.*, (b.${BankAccountFields.startingValue} +
@@ -160,7 +160,10 @@ class BankAccountMethods extends SossoldiDatabase {
                ELSE 0 END)
     ) as ${BankAccountFields.total}
       FROM $bankAccountTable as b
-      LEFT JOIN "$transactionTable" as t ON t.${TransactionFields.idBankAccount} = b.${BankAccountFields.id} OR t.${TransactionFields.idBankAccountTransfer} = b.${BankAccountFields.id}
+      LEFT JOIN "$transactionTable" as t
+             ON (t.${TransactionFields.idBankAccount} = b.${BankAccountFields.id} OR
+                 t.${TransactionFields.idBankAccountTransfer} = b.${BankAccountFields.id})
+             AND $recurringFilter
       WHERE $where
       GROUP BY b.${BankAccountFields.id}
       ORDER BY $orderByASC


### PR DESCRIPTION
This pull request addresses a bug where active bank accounts with only recurring transactions were being excluded from the query results.

### Changes:
- Corrected the SQL query to ensure that active bank accounts with only recurring transactions are no longer excluded from the results.
- Added a new `recurringFilter` variable to clearly define and encapsulate the logic for filtering out non-recurring transactions.
- Adjusted the `LEFT JOIN` clause to apply the recurring filter within the `ON` condition, preserving all active accounts while accurately calculating their balances.
- This fix resolves an issue where certain accounts disappeared from the query results, ensuring all active accounts are correctly handled in the balance calculation.

### Issue Demonstration:

This video demonstrates the issue that this pull request resolves:

https://github.com/user-attachments/assets/ff05cc92-8d7b-4b3e-871d-bd51d4267d42

### Testing:

- Verified that all active accounts are now included in the query results, even those with only recurring transactions.
- Conducted extensive testing to ensure that the fix does not introduce any regressions and that the balance calculations remain accurate.

Please review the changes and let me know if you have any feedback. Thank you!


