### PR TITLE
Bug fix: Prevent user to create budgets for income categories

### DIFF
--- a/lib/pages/categories/add_category.dart
+++ b/lib/pages/categories/add_category.dart
@@ -9,7 +9,9 @@ import '../../providers/categories_provider.dart';
 final showCategoryIconsProvider = StateProvider.autoDispose<bool>((ref) => false);
 
 class AddCategory extends ConsumerStatefulWidget {
-  const AddCategory({super.key});
+  final bool hideIncome;
+
+  const AddCategory({super.key, this.hideIncome = false});
 
   @override
   ConsumerState<AddCategory> createState() => _AddCategoryState();
@@ -98,7 +100,10 @@ class _AddCategoryState extends ConsumerState<AddCategory> with Functions {
                         value: categoryType,
                         underline: const SizedBox(),
                         isExpanded: true,
-                        items: CategoryTransactionType.values.map((CategoryTransactionType type) {
+                        items: (widget.hideIncome
+                                ? [CategoryTransactionType.expense] // Only show 'expense' if true
+                                : CategoryTransactionType.values) // Otherwise, show all values
+                            .map((CategoryTransactionType type) {
                           return DropdownMenuItem<CategoryTransactionType>(
                             value: type,
                             child: Text(

--- a/lib/pages/onboarding_page/widgets/budget_setup.dart
+++ b/lib/pages/onboarding_page/widgets/budget_setup.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../categories/add_category.dart';
 import '/constants/constants.dart';
 import '/constants/style.dart';
 import '/model/budget.dart';
@@ -84,7 +85,14 @@ class _BudgetSetupState extends ConsumerState<BudgetSetup> {
                               ));
                         } else {
                           return GestureDetector(
-                            onTap: () => Navigator.of(context).pushNamed('/add-category'),
+                            onTap: () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => AddCategory(hideIncome: true),
+                                ),
+                              );
+                            },
                             child: const AddCategoryButton(),
                           );
                         }

--- a/lib/pages/planning_page/manage_budget_page.dart
+++ b/lib/pages/planning_page/manage_budget_page.dart
@@ -23,6 +23,7 @@ class _ManageBudgetPageState extends ConsumerState<ManageBudgetPage> {
 
   void _loadCategories() async {
     categories = await ref.read(categoriesProvider.notifier).getCategories();
+    categories.removeWhere((element) => element.type == CategoryTransactionType.income);
     budgets = await ref.read(budgetsProvider.notifier).getBudgets();
     setState(() {});
   }

--- a/lib/providers/categories_provider.dart
+++ b/lib/providers/categories_provider.dart
@@ -12,7 +12,7 @@ final selectedCategoryProvider =
     StateProvider<CategoryTransaction?>((ref) => null);
 
 final categoryTypeProvider = StateProvider<CategoryTransactionType>(
-    (ref) => CategoryTransactionType.income); //default as 'Income'
+    (ref) => CategoryTransactionType.expense); //default as 'Expense'
 
 final categoryIconProvider =
     StateProvider<String>((ref) => iconList.keys.first);


### PR DESCRIPTION
Currently a user could create an income category and then add a budget to it. This PR aims at resolving this by doing the following things:
1. During the Onboarding phase the user can only create Expense categories and add a budget to them
2. In the planning page when I user wants to create a new budget only the Expense categories are shown