### PR TITLE
Bug fix/187: update account after updating transaction

### DIFF
--- a/lib/pages/add_page/add_page.dart
+++ b/lib/pages/add_page/add_page.dart
@@ -32,8 +32,10 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
 
   @override
   void initState() {
-    amountController.text = numToCurrency(ref.read(selectedTransactionUpdateProvider)?.amount);
-    noteController.text = ref.read(selectedTransactionUpdateProvider)?.note ?? '';
+    amountController.text =
+        numToCurrency(ref.read(selectedTransactionUpdateProvider)?.amount);
+    noteController.text =
+        ref.read(selectedTransactionUpdateProvider)?.note ?? '';
 
     amountController.addListener(_updateAmount);
 
@@ -48,7 +50,9 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
 
     if (recurrencyEditingPermittedFromRoute == null) {
       final argsMap = args as Map<String, dynamic>?;
-      recurrencyEditingPermittedFromRoute = argsMap?['recurrencyEditingPermitted'] ?? widget.recurrencyEditingPermitted;
+      recurrencyEditingPermittedFromRoute =
+          argsMap?['recurrencyEditingPermitted'] ??
+              widget.recurrencyEditingPermitted;
     }
   }
 
@@ -61,7 +65,8 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
 
   String getCleanAmountString() {
     // Remove all non-numeric characters
-    var cleanNumberString = amountController.text.replaceAll(RegExp(r'[^0-9\.]'), '');
+    var cleanNumberString =
+        amountController.text.replaceAll(RegExp(r'[^0-9\.]'), '');
 
     // Remove leading zeros
     return cleanNumberString.replaceAll(RegExp(r'^[0\.]+(?=.)'), '');
@@ -88,10 +93,11 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
     }
   }
 
-  void _updateAccount() {
+  void _refreshAccountAndNavigateBack() {
     ref
         .read(accountsProvider.notifier)
-        .updateAccount(ref.watch(bankAccountProvider)!.name);
+        .selectAndUpdateAccount(ref.read(bankAccountProvider)!)
+        .whenComplete(() => Navigator.of(context).pop());
   }
 
   void _createOrUpdateTransaction() {
@@ -105,53 +111,57 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
       if (selectedTransaction != null) {
         // if the original transaction is not recurrent, but user sets a recurrency, add the corrispondent record
         // and edit the original transaction
-        if(ref.read(selectedRecurringPayProvider) && !selectedTransaction.recurring) {
+        if (ref.read(selectedRecurringPayProvider) &&
+            !selectedTransaction.recurring) {
           ref
               .read(transactionsProvider.notifier)
-              .addRecurringTransaction(currencyToNum(cleanAmount), noteController.text)
+              .addRecurringTransaction(
+                  currencyToNum(cleanAmount), noteController.text)
               .then((value) {
-                if (value != null) {
-                  ref
-                      .read(transactionsProvider.notifier)
-                      .updateTransaction(currencyToNum(cleanAmount), noteController.text, value.id)
-                      .whenComplete(() => Navigator.of(context).pop());
-                }
-              });
+            if (value != null) {
+              ref
+                  .read(transactionsProvider.notifier)
+                  .updateTransaction(
+                      currencyToNum(cleanAmount), noteController.text, value.id)
+                  .whenComplete(() => _refreshAccountAndNavigateBack());
+            }
+          });
         } else {
           ref
               .read(transactionsProvider.notifier)
-              .updateTransaction(currencyToNum(cleanAmount), noteController.text, selectedTransaction.idRecurringTransaction)
-              .whenComplete(() => Navigator.of(context).pop());
+              .updateTransaction(
+                  currencyToNum(cleanAmount),
+                  noteController.text,
+                  selectedTransaction.idRecurringTransaction)
+              .whenComplete(() => _refreshAccountAndNavigateBack());
         }
-
-
       } else {
         if (selectedType == TransactionType.transfer) {
           if (ref.read(bankAccountTransferProvider) != null) {
             ref
                 .read(transactionsProvider.notifier)
                 .addTransaction(currencyToNum(cleanAmount), noteController.text)
-                .whenComplete(() => Navigator.of(context).pop());
+                .whenComplete(() => _refreshAccountAndNavigateBack());
           }
         } else {
           // It's an income or an expense
           if (ref.read(categoryProvider) != null) {
-            if(ref.read(selectedRecurringPayProvider)) {
+            if (ref.read(selectedRecurringPayProvider)) {
               ref
-                .read(transactionsProvider.notifier)
-                .addRecurringTransaction(currencyToNum(cleanAmount), noteController.text)
-                .whenComplete(() => Navigator.of(context).pop());
+                  .read(transactionsProvider.notifier)
+                  .addRecurringTransaction(
+                      currencyToNum(cleanAmount), noteController.text)
+                  .whenComplete(() => _refreshAccountAndNavigateBack());
             } else {
               ref
-                .read(transactionsProvider.notifier)
-                .addTransaction(currencyToNum(cleanAmount), noteController.text)
-                .whenComplete(() => Navigator.of(context).pop());
+                  .read(transactionsProvider.notifier)
+                  .addTransaction(
+                      currencyToNum(cleanAmount), noteController.text)
+                  .whenComplete(() => _refreshAccountAndNavigateBack());
             }
           }
         }
       }
-
-      _updateAccount();
     }
   }
 
@@ -160,8 +170,7 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
     ref
         .read(transactionsProvider.notifier)
         .deleteTransaction(selectedTransaction!.id!)
-        .whenComplete(() => Navigator.pop(context));
-    _updateAccount();
+        .whenComplete(() => _refreshAccountAndNavigateBack());
   }
 
   @override
@@ -174,14 +183,17 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
     return Scaffold(
       appBar: AppBar(
         title: Text(
-          (selectedTransaction != null) ? "Editing transaction" : "New transaction",
+          (selectedTransaction != null)
+              ? "Editing transaction"
+              : "New transaction",
         ),
         leadingWidth: 100,
         leading: TextButton(
           onPressed: () => Navigator.pop(context),
           child: Text(
             'Cancel',
-            style: Theme.of(context).textTheme.titleMedium!.copyWith(color: blue5),
+            style:
+                Theme.of(context).textTheme.titleMedium!.copyWith(color: blue5),
           ),
         ),
         actions: [
@@ -303,8 +315,9 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
                                   minimumYear: 2015,
                                   maximumYear: 2050,
                                   mode: CupertinoDatePickerMode.date,
-                                  onDateTimeChanged: (date) =>
-                                      ref.read(dateProvider.notifier).state = date,
+                                  onDateTimeChanged: (date) => ref
+                                      .read(dateProvider.notifier)
+                                      .state = date,
                                 ),
                               ),
                             );
@@ -316,16 +329,18 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
                               lastDate: DateTime(2050),
                             );
                             if (pickedDate != null) {
-                              ref.read(dateProvider.notifier).state = pickedDate;
+                              ref.read(dateProvider.notifier).state =
+                                  pickedDate;
                             }
                           }
                         },
                       ),
                       if (selectedType == TransactionType.expense) ...[
                         RecurrenceListTile(
-                            recurrencyEditingPermitted: widget.recurrencyEditingPermitted,
-                            selectedTransaction: ref.read(selectedTransactionUpdateProvider)
-                        )
+                            recurrencyEditingPermitted:
+                                widget.recurrencyEditingPermitted,
+                            selectedTransaction:
+                                ref.read(selectedTransactionUpdateProvider))
                       ],
                     ],
                   ),
@@ -359,14 +374,15 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
                   onPressed: _createOrUpdateTransaction,
                   style: TextButton.styleFrom(
                     backgroundColor: Theme.of(context).colorScheme.secondary,
-                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8)),
                   ),
                   child: Text(
-                    selectedTransaction != null ? "UPDATE TRANSACTION" : "ADD TRANSACTION",
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyLarge!
-                        .copyWith(color: Theme.of(context).colorScheme.onPrimary),
+                    selectedTransaction != null
+                        ? "UPDATE TRANSACTION"
+                        : "ADD TRANSACTION",
+                    style: Theme.of(context).textTheme.bodyLarge!.copyWith(
+                        color: Theme.of(context).colorScheme.onPrimary),
                   ),
                 ),
               ),

--- a/lib/pages/add_page/add_page.dart
+++ b/lib/pages/add_page/add_page.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../constants/functions.dart';
 import '../../constants/style.dart';
 import '../../model/transaction.dart';
+import '../../providers/accounts_provider.dart';
 import '../../providers/transactions_provider.dart';
 import "widgets/account_selector.dart";
 import 'widgets/amount_section.dart';
@@ -87,6 +88,12 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
     }
   }
 
+  void _updateAccount() {
+    ref
+        .read(accountsProvider.notifier)
+        .updateAccount(ref.watch(bankAccountProvider)!.name);
+  }
+
   void _createOrUpdateTransaction() {
     final selectedType = ref.read(transactionTypeProvider);
     final selectedTransaction = ref.read(selectedTransactionUpdateProvider);
@@ -143,7 +150,18 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
           }
         }
       }
+
+      _updateAccount();
     }
+  }
+
+  void _deleteTransaction() {
+    final selectedTransaction = ref.read(selectedTransactionUpdateProvider);
+    ref
+        .read(transactionsProvider.notifier)
+        .deleteTransaction(selectedTransaction!.id!)
+        .whenComplete(() => Navigator.pop(context));
+    _updateAccount();
   }
 
   @override
@@ -175,12 +193,7 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
                       Icons.delete_outline,
                       color: Theme.of(context).colorScheme.error,
                     ),
-                    onPressed: () async {
-                      ref
-                          .read(transactionsProvider.notifier)
-                          .deleteTransaction(selectedTransaction.id!)
-                          .whenComplete(() => Navigator.pop(context));
-                    },
+                    onPressed: _deleteTransaction,
                   ),
                 )
               : const SizedBox(),

--- a/lib/providers/accounts_provider.dart
+++ b/lib/providers/accounts_provider.dart
@@ -56,6 +56,11 @@ class AsyncAccountsNotifier extends AsyncNotifier<List<BankAccount>> {
     });
   }
 
+  Future<void> selectAndUpdateAccount(BankAccount account) async {
+    await selectedAccount(account);
+    await updateAccount(account.name);
+  }
+
   Future<void> updateAccount(String name) async {
     BankAccount account = ref.read(selectedAccountProvider)!.copy(
           name: name,


### PR DESCRIPTION
Currently The account is not updated after changes in transations.

This PR will:

- Add an updateAccount method inside the add_page view
- Add call to updateAccount when creating or updating transaction
- Add call to updateAccount when removing transaction

Closes #187 


https://github.com/user-attachments/assets/312b3a55-5564-4f98-bd0f-ec150bfd5880

