### PR TITLE
feat(transaction): duplicate transaction

### DIFF
--- a/lib/model/transaction.dart
+++ b/lib/model/transaction.dart
@@ -48,7 +48,15 @@ Map<String, TransactionType> typeMap = {
   "TRSF": TransactionType.transfer,
 };
 
-enum Recurrence { daily, weekly, monthly, bimonthly, quarterly, semester, annual }
+enum Recurrence {
+  daily,
+  weekly,
+  monthly,
+  bimonthly,
+  quarterly,
+  semester,
+  annual
+}
 
 class RecurrenceData {
   final Recurrence recurrence;
@@ -63,20 +71,32 @@ class RecurrenceData {
 }
 
 Map<Recurrence, RecurrenceData> recurrenceMap = {
-  Recurrence.daily: RecurrenceData(recurrence: Recurrence.daily, label: "Daily", days: 1),
-  Recurrence.weekly: RecurrenceData(recurrence: Recurrence.weekly, label: "Weekly", days: 7),
-  Recurrence.monthly: RecurrenceData(recurrence: Recurrence.monthly, label: "Monthly", days: 30),
-  Recurrence.bimonthly: RecurrenceData(recurrence: Recurrence.bimonthly, label: "Bimonthly", days: 60),
-  Recurrence.quarterly: RecurrenceData(recurrence: Recurrence.quarterly, label: "Quarterly", days: 90),
-  Recurrence.semester: RecurrenceData(recurrence: Recurrence.semester, label: "Semester", days: 180),
-  Recurrence.annual: RecurrenceData(recurrence: Recurrence.annual, label: "Annual", days: 365),
+  Recurrence.daily:
+      RecurrenceData(recurrence: Recurrence.daily, label: "Daily", days: 1),
+  Recurrence.weekly:
+      RecurrenceData(recurrence: Recurrence.weekly, label: "Weekly", days: 7),
+  Recurrence.monthly: RecurrenceData(
+      recurrence: Recurrence.monthly, label: "Monthly", days: 30),
+  Recurrence.bimonthly: RecurrenceData(
+      recurrence: Recurrence.bimonthly, label: "Bimonthly", days: 60),
+  Recurrence.quarterly: RecurrenceData(
+      recurrence: Recurrence.quarterly, label: "Quarterly", days: 90),
+  Recurrence.semester: RecurrenceData(
+      recurrence: Recurrence.semester, label: "Semester", days: 180),
+  Recurrence.annual:
+      RecurrenceData(recurrence: Recurrence.annual, label: "Annual", days: 365),
 };
 
 Recurrence parseRecurrence(String s) {
-  return recurrenceMap.entries.firstWhere((entry) => entry.value.label.toLowerCase() == s.toLowerCase()).key;
+  return recurrenceMap.entries
+      .firstWhere((entry) => entry.value.label.toLowerCase() == s.toLowerCase())
+      .key;
 }
 
 class Transaction extends BaseEntity {
+  // This is to allow to manually set a null value to id field.
+  static const _unset = Object();
+
   final DateTime date;
   final num amount;
   final TransactionType type;
@@ -112,7 +132,7 @@ class Transaction extends BaseEntity {
       super.updatedAt});
 
   Transaction copy(
-          {int? id,
+          {Object? id = _unset,
           DateTime? date,
           num? amount,
           TransactionType? type,
@@ -125,16 +145,18 @@ class Transaction extends BaseEntity {
           DateTime? createdAt,
           DateTime? updatedAt}) =>
       Transaction(
-          id: id ?? this.id,
+          id: id == _unset ? this.id : (id as int?),
           date: date ?? this.date,
           amount: amount ?? this.amount,
           type: type ?? this.type,
           note: note ?? this.note,
           idCategory: idCategory ?? this.idCategory,
           idBankAccount: idBankAccount ?? this.idBankAccount,
-          idBankAccountTransfer: idBankAccountTransfer ?? this.idBankAccountTransfer,
+          idBankAccountTransfer:
+              idBankAccountTransfer ?? this.idBankAccountTransfer,
           recurring: recurring ?? this.recurring,
-          idRecurringTransaction: idRecurringTransaction ?? this.idRecurringTransaction,
+          idRecurringTransaction:
+              idRecurringTransaction ?? this.idRecurringTransaction,
           createdAt: createdAt ?? this.createdAt,
           updatedAt: updatedAt ?? this.updatedAt);
 
@@ -150,10 +172,13 @@ class Transaction extends BaseEntity {
       categorySymbol: json[TransactionFields.categorySymbol] as String?,
       idBankAccount: json[TransactionFields.idBankAccount] as int,
       bankAccountName: json[TransactionFields.bankAccountName] as String?,
-      idBankAccountTransfer: json[TransactionFields.idBankAccountTransfer] as int?,
-      bankAccountTransferName: json[TransactionFields.bankAccountTransferName] as String?,
+      idBankAccountTransfer:
+          json[TransactionFields.idBankAccountTransfer] as int?,
+      bankAccountTransferName:
+          json[TransactionFields.bankAccountTransferName] as String?,
       recurring: json[TransactionFields.recurring] == 1 ? true : false,
-      idRecurringTransaction: json[TransactionFields.idRecurringTransaction] as int?,
+      idRecurringTransaction:
+          json[TransactionFields.idRecurringTransaction] as int?,
       createdAt: DateTime.parse(json[BaseEntityFields.createdAt] as String),
       updatedAt: DateTime.parse(json[BaseEntityFields.updatedAt] as String));
 
@@ -161,15 +186,17 @@ class Transaction extends BaseEntity {
         TransactionFields.id: id,
         TransactionFields.date: date.toIso8601String(),
         TransactionFields.amount: amount,
-        TransactionFields.type: typeMap.keys.firstWhere((k) => typeMap[k] == type),
+        TransactionFields.type:
+            typeMap.keys.firstWhere((k) => typeMap[k] == type),
         TransactionFields.note: note,
         TransactionFields.idCategory: idCategory,
         TransactionFields.idBankAccount: idBankAccount,
         TransactionFields.idBankAccountTransfer: idBankAccountTransfer,
         TransactionFields.recurring: recurring ? 1 : 0,
         TransactionFields.idRecurringTransaction: idRecurringTransaction,
-        BaseEntityFields.createdAt:
-            update ? createdAt?.toIso8601String() : DateTime.now().toIso8601String(),
+        BaseEntityFields.createdAt: update
+            ? createdAt?.toIso8601String()
+            : DateTime.now().toIso8601String(),
         BaseEntityFields.updatedAt: DateTime.now().toIso8601String(),
       };
 }
@@ -185,24 +212,24 @@ class TransactionMethods extends SossoldiDatabase {
     final db = await database;
 
     final maps = await db.rawQuery('''
-      SELECT t.*, 
-        c.${CategoryTransactionFields.name} as ${TransactionFields.categoryName}, 
-        c.${CategoryTransactionFields.color} as ${TransactionFields.categoryColor}, 
-        c.${CategoryTransactionFields.symbol} as ${TransactionFields.categorySymbol}, 
-        b1.${BankAccountFields.name} as ${TransactionFields.bankAccountName}, 
-        b2.${BankAccountFields.name} as ${TransactionFields.bankAccountTransferName} 
-      FROM 
-        '$transactionTable' as t 
-      LEFT JOIN 
-        $categoryTransactionTable as c ON t.${TransactionFields.idCategory} = c.${CategoryTransactionFields.id} 
-      LEFT JOIN 
-        $bankAccountTable as b1 ON t.${TransactionFields.idBankAccount} = b1.${BankAccountFields.id} 
-      LEFT JOIN 
-        $bankAccountTable as b2 ON t.${TransactionFields.idBankAccountTransfer} = b2.${BankAccountFields.id} 
-      WHERE 
+      SELECT t.*,
+        c.${CategoryTransactionFields.name} as ${TransactionFields.categoryName},
+        c.${CategoryTransactionFields.color} as ${TransactionFields.categoryColor},
+        c.${CategoryTransactionFields.symbol} as ${TransactionFields.categorySymbol},
+        b1.${BankAccountFields.name} as ${TransactionFields.bankAccountName},
+        b2.${BankAccountFields.name} as ${TransactionFields.bankAccountTransferName}
+      FROM
+        '$transactionTable' as t
+      LEFT JOIN
+        $categoryTransactionTable as c ON t.${TransactionFields.idCategory} = c.${CategoryTransactionFields.id}
+      LEFT JOIN
+        $bankAccountTable as b1 ON t.${TransactionFields.idBankAccount} = b1.${BankAccountFields.id}
+      LEFT JOIN
+        $bankAccountTable as b2 ON t.${TransactionFields.idBankAccountTransfer} = b2.${BankAccountFields.id}
+      WHERE
         t.${TransactionFields.id} = ?
     ''', [id]);
-    
+
     if (maps.isNotEmpty) {
       return Transaction.fromJson(maps.first);
     } else {
@@ -221,7 +248,9 @@ class TransactionMethods extends SossoldiDatabase {
       Map<int, bool>? bankAccounts}) async {
     final db = await database;
 
-    String? where = type != null ? '${TransactionFields.type} = $type' : null; // filter type
+    String? where = type != null
+        ? '${TransactionFields.type} = $type'
+        : null; // filter type
     if (date != null) {
       where =
           "${where != null ? '$where and ' : ''}strftime('%Y-%m-%d', ${TransactionFields.date}) >= '${date.toString().substring(0, 10)}' and ${TransactionFields.date} <= '${date.toIso8601String().substring(0, 10)}'";
@@ -236,12 +265,15 @@ class TransactionMethods extends SossoldiDatabase {
 
     if (transactionType != null) {
       final transactionTypeList = transactionType.map((e) => "'$e'").toList();
-      where = "${where != null ? '$where and ' : ''}t.type IN (${transactionTypeList.join(',')}) ";
+      where =
+          "${where != null ? '$where and ' : ''}t.type IN (${transactionTypeList.join(',')}) ";
     }
 
-    if (bankAccounts != null && !bankAccounts.entries.every((element) => element.value == false)) {
-      final bankAccountIds =
-          bankAccounts.entries.where((bankAccount) => bankAccount.value).map((e) => "'${e.key}'");
+    if (bankAccounts != null &&
+        !bankAccounts.entries.every((element) => element.value == false)) {
+      final bankAccountIds = bankAccounts.entries
+          .where((bankAccount) => bankAccount.value)
+          .map((e) => "'${e.key}'");
       where =
           "${where != null ? '$where and ' : ''}t.${TransactionFields.idBankAccount} IN (${bankAccountIds.join(',')}) ";
     }
@@ -254,10 +286,11 @@ class TransactionMethods extends SossoldiDatabase {
     return result.map((json) => Transaction.fromJson(json)).toList();
   }
 
-  Future<List<Transaction>> getRecurrenceTransactionsById({int? id}) async  {
-    final db = await database; 
+  Future<List<Transaction>> getRecurrenceTransactionsById({int? id}) async {
+    final db = await database;
 
-    final result = await db.rawQuery('SELECT * FROM "$transactionTable" as t WHERE t.${TransactionFields.idRecurringTransaction} = $id ORDER BY ${TransactionFields.date} DESC');
+    final result = await db.rawQuery(
+        'SELECT * FROM "$transactionTable" as t WHERE t.${TransactionFields.idRecurringTransaction} = $id ORDER BY ${TransactionFields.date} DESC');
 
     return result.map((json) => Transaction.fromJson(json)).toList();
   }
@@ -348,8 +381,9 @@ class TransactionMethods extends SossoldiDatabase {
         throw ArgumentError("Query not implemented for frequency $recurrence");
     }
 
-    final accountFilter =
-        accountId != null ? "${TransactionFields.idBankAccount} = $accountId" : "";
+    final accountFilter = accountId != null
+        ? "${TransactionFields.idBankAccount} = $accountId"
+        : "";
     //var periodDateFormatter = "";
     final periodFilterStart = dateRangeStart != null
         ? "strftime('%Y-%m-%d', ${TransactionFields.date}) >= '${dateRangeStart.toString().substring(0, 10)}'"

--- a/lib/pages/add_page/add_page.dart
+++ b/lib/pages/add_page/add_page.dart
@@ -13,6 +13,7 @@ import "widgets/account_selector.dart";
 import 'widgets/amount_section.dart';
 import "widgets/category_selector.dart";
 import 'widgets/details_list_tile.dart';
+import 'widgets/duplicate_transaction_dialog.dart';
 import 'widgets/label_list_tile.dart';
 import 'widgets/recurrence_list_tile.dart';
 
@@ -208,23 +209,26 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
               ? "Editing transaction"
               : "New transaction",
         ),
-        leadingWidth: 100,
-        leading: TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: Text('Cancel'),
-        ),
         actions: [
-          if (selectedTransaction != null)
-            Container(
-              alignment: Alignment.centerRight,
-              child: IconButton(
-                icon: Icon(
-                  Icons.delete_outline,
-                  color: Theme.of(context).colorScheme.error,
-                ),
-                onPressed: _deleteTransaction,
+          if (selectedTransaction != null) ...[
+            IconButton(
+              icon: Icon(
+                Icons.copy,
+                size: 20,
+                color: Theme.of(context).colorScheme.primary,
               ),
+              onPressed: () => showDialog(context: context, builder: (_) => DuplicateTransactionDialog(
+                transaction: selectedTransaction,
+              )),
             ),
+            IconButton(
+              icon: Icon(
+                Icons.delete_outline,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              onPressed: _deleteTransaction,
+            ),
+          ]
         ],
       ),
       body: Column(

--- a/lib/pages/add_page/widgets/duplicate_transaction_dialog.dart
+++ b/lib/pages/add_page/widgets/duplicate_transaction_dialog.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../model/transaction.dart';
+import '../../../providers/transactions_provider.dart';
+
+class DuplicateTransactionDialog extends ConsumerWidget {
+  const DuplicateTransactionDialog({super.key, required this.transaction});
+
+  final Transaction transaction;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return AlertDialog(
+      title: const Text("Duplicate transaction"),
+      content: const Text(
+        "This transaction is already in the list. Do you want to duplicate it? You can then edit the new transaction.",
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: Text(
+            "Cancel",
+            style: TextStyle(fontSize: 14),
+          ),
+        ),
+        ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          ),
+          onPressed: () => ref
+              .read(transactionsProvider.notifier)
+              .duplicateTransaction(transaction)
+              .whenComplete(() {
+            if (context.mounted) Navigator.of(context).pop();
+          }),
+          child: const Text("Duplicate"),
+        ),
+      ],
+    );
+  }
+}

--- a/test/model/transaction_test.dart
+++ b/test/model/transaction_test.dart
@@ -23,12 +23,43 @@ void main() {
         idRecurringTransaction: null,
         idCategory: 1,
         createdAt: DateTime.utc(2022),
-        updatedAt: DateTime.utc(2022)
-    );
+        updatedAt: DateTime.utc(2022));
 
     Transaction tCopy = t.copy(id: 10);
 
     assert(tCopy.id == 10);
+    assert(tCopy.date == t.date);
+    assert(tCopy.amount == t.amount);
+    assert(tCopy.date == t.date);
+    assert(tCopy.type == t.type);
+    assert(tCopy.note == t.note);
+    assert(tCopy.idBankAccount == t.idBankAccount);
+    assert(tCopy.idCategory == t.idCategory);
+    assert(tCopy.idBankAccountTransfer == t.idBankAccountTransfer);
+    assert(tCopy.recurring == t.recurring);
+    assert(tCopy.idRecurringTransaction == t.idRecurringTransaction);
+    assert(tCopy.createdAt == t.createdAt);
+    assert(tCopy.updatedAt == t.updatedAt);
+  });
+
+  test("Copy with null id", () async {
+    Transaction t = Transaction(
+        id: 2,
+        date: DateTime.utc(2022),
+        amount: 100,
+        type: TransactionType.income,
+        note: "Note",
+        idBankAccount: 0,
+        idBankAccountTransfer: null,
+        recurring: false,
+        idRecurringTransaction: null,
+        idCategory: 1,
+        createdAt: DateTime.utc(2022),
+        updatedAt: DateTime.utc(2022));
+
+    Transaction tCopy = t.copy(id: null);
+
+    assert(tCopy.id == null);
     assert(tCopy.date == t.date);
     assert(tCopy.amount == t.amount);
     assert(tCopy.date == t.date);
@@ -67,9 +98,11 @@ void main() {
     assert(t.type == typeMap[json[TransactionFields.type]]);
     assert(t.note == json[TransactionFields.note]);
     assert(t.idBankAccount == json[TransactionFields.idBankAccount]);
-    assert(t.idBankAccountTransfer == json[TransactionFields.idBankAccountTransfer]);
+    assert(t.idBankAccountTransfer ==
+        json[TransactionFields.idBankAccountTransfer]);
     assert(t.recurring == json[TransactionFields.recurring]);
-    assert(t.idRecurringTransaction == json[TransactionFields.idRecurringTransaction]);
+    assert(t.idRecurringTransaction ==
+        json[TransactionFields.idRecurringTransaction]);
     assert(t.idCategory == json[TransactionFields.idCategory]);
     assert(t.createdAt?.toUtc().toIso8601String() ==
         json[BaseEntityFields.createdAt]);
@@ -88,8 +121,7 @@ void main() {
         idBankAccount: 0,
         idBankAccountTransfer: null,
         recurring: false,
-        idRecurringTransaction: null
-    );
+        idRecurringTransaction: null);
 
     Map<String, Object?> json = t.toJson();
 
@@ -100,13 +132,14 @@ void main() {
     assert(t.note == json[TransactionFields.note]);
     assert(t.idCategory == json[TransactionFields.idCategory]);
     assert(t.idBankAccount == json[TransactionFields.idBankAccount]);
-    assert(t.idBankAccountTransfer == json[TransactionFields.idBankAccountTransfer]);
+    assert(t.idBankAccountTransfer ==
+        json[TransactionFields.idBankAccountTransfer]);
     assert((t.recurring ? 1 : 0) == json[TransactionFields.recurring]);
-    assert(t.idRecurringTransaction == json[TransactionFields.idRecurringTransaction]);
+    assert(t.idRecurringTransaction ==
+        json[TransactionFields.idRecurringTransaction]);
   });
 
   group("Transaction Methods", () {
-
     late SossoldiDatabase sossoldiDatabase;
     late sqflite.Database db;
 
@@ -118,9 +151,7 @@ void main() {
       await sossoldiDatabase.clearDatabase();
     });
 
-    tearDown(() async => {
-      await sossoldiDatabase.clearDatabase()
-    });
+    tearDown(() async => {await sossoldiDatabase.clearDatabase()});
 
     tearDownAll(() {
       sossoldiDatabase.close();
@@ -129,37 +160,47 @@ void main() {
     test("lastMonthDailyTransactions", () async {
       await sossoldiDatabase.fillDemoData(countOfGeneratedTransaction: 2000);
 
-      try{
+      try {
         await db.transaction((txn) async {
           var batch = txn.batch();
           batch.delete(transactionTable);
           await batch.commit();
         });
-      } catch(error){
+      } catch (error) {
         throw Exception('DbBase.cleanDatabase: $error');
       }
 
-      const insertDemoTransactionsQuery = '''INSERT INTO `transaction` (date, amount, type, note, idCategory, idBankAccount, idBankAccountTransfer, recurring, idRecurringTransaction, createdAt, updatedAt) VALUES ''';
+      const insertDemoTransactionsQuery =
+          '''INSERT INTO `transaction` (date, amount, type, note, idCategory, idBankAccount, idBankAccountTransfer, recurring, idRecurringTransaction, createdAt, updatedAt) VALUES ''';
       final List<String> demoTransactions = [];
 
       final today = DateTime.now();
       final fistOfLastMonth = DateTime(today.year, today.month - 1, 1);
 
       // Add a transaction of two month ago
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfLastMonth.subtract(const Duration(days: 10))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfLastMonth.subtract(const Duration(days: 10))));
 
       // Add transactions of last month
       demoTransactions.add(createInsertSqlTransaction(date: fistOfLastMonth));
       demoTransactions.add(createInsertSqlTransaction(date: fistOfLastMonth));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfLastMonth.add(const Duration(days: 1))));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfLastMonth.add(const Duration(days: 1)), amount: 200, type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfLastMonth.add(const Duration(days: 2)), type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfLastMonth.add(const Duration(days: 2)), type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfLastMonth.add(const Duration(days: 1))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfLastMonth.add(const Duration(days: 1)),
+          amount: 200,
+          type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfLastMonth.add(const Duration(days: 2)), type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfLastMonth.add(const Duration(days: 2)), type: 'IN'));
 
       // Add a transaction of current month
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfLastMonth.add(const Duration(days: 32))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfLastMonth.add(const Duration(days: 32))));
 
-      await db.execute("$insertDemoTransactionsQuery ${demoTransactions.join(",")};");
+      await db.execute(
+          "$insertDemoTransactionsQuery ${demoTransactions.join(",")};");
 
       var result = await TransactionMethods().lastMonthDailyTransactions();
       expect(result.length, 3);
@@ -170,11 +211,13 @@ void main() {
       expect(result[0]['income'], 0);
       expect(result[0]['expense'], 200);
 
-      expect(result[1]['day'], formatter.format(fistOfLastMonth.add(const Duration(days: 1))));
+      expect(result[1]['day'],
+          formatter.format(fistOfLastMonth.add(const Duration(days: 1))));
       expect(result[1]['income'], 200);
       expect(result[1]['expense'], 100);
 
-      expect(result[2]['day'], formatter.format(fistOfLastMonth.add(const Duration(days: 2))));
+      expect(result[2]['day'],
+          formatter.format(fistOfLastMonth.add(const Duration(days: 2))));
       expect(result[2]['income'], 200);
       expect(result[2]['expense'], 0);
     });
@@ -182,37 +225,49 @@ void main() {
     test("currentMonthDailyTransactions", () async {
       await sossoldiDatabase.fillDemoData(countOfGeneratedTransaction: 2000);
 
-      try{
+      try {
         await db.transaction((txn) async {
           var batch = txn.batch();
           batch.delete(transactionTable);
           await batch.commit();
         });
-      } catch(error){
+      } catch (error) {
         throw Exception('DbBase.cleanDatabase: $error');
       }
 
-      const insertDemoTransactionsQuery = '''INSERT INTO `transaction` (date, amount, type, note, idCategory, idBankAccount, idBankAccountTransfer, recurring, idRecurringTransaction, createdAt, updatedAt) VALUES ''';
+      const insertDemoTransactionsQuery =
+          '''INSERT INTO `transaction` (date, amount, type, note, idCategory, idBankAccount, idBankAccountTransfer, recurring, idRecurringTransaction, createdAt, updatedAt) VALUES ''';
       final List<String> demoTransactions = [];
 
       final today = DateTime.now();
       final fistOfCurrentMonth = DateTime(today.year, today.month, 1);
 
       // Add a transaction of last month
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.subtract(const Duration(days: 10))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.subtract(const Duration(days: 10))));
 
       // Add transactions of current month
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.add(const Duration(days: 1))));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.add(const Duration(days: 1)), amount: 200, type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.add(const Duration(days: 2)), type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.add(const Duration(days: 2)), type: 'IN'));
+      demoTransactions
+          .add(createInsertSqlTransaction(date: fistOfCurrentMonth));
+      demoTransactions
+          .add(createInsertSqlTransaction(date: fistOfCurrentMonth));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.add(const Duration(days: 1))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.add(const Duration(days: 1)),
+          amount: 200,
+          type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.add(const Duration(days: 2)), type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.add(const Duration(days: 2)), type: 'IN'));
 
       // Add a transaction of next month
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.add(const Duration(days: 32))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.add(const Duration(days: 32))));
 
-      await db.execute("$insertDemoTransactionsQuery ${demoTransactions.join(",")};");
+      await db.execute(
+          "$insertDemoTransactionsQuery ${demoTransactions.join(",")};");
 
       var result = await TransactionMethods().currentMonthDailyTransactions();
       expect(result.length, 3);
@@ -223,11 +278,13 @@ void main() {
       expect(result[0]['income'], 0);
       expect(result[0]['expense'], 200);
 
-      expect(result[1]['day'], formatter.format(fistOfCurrentMonth.add(const Duration(days: 1))));
+      expect(result[1]['day'],
+          formatter.format(fistOfCurrentMonth.add(const Duration(days: 1))));
       expect(result[1]['income'], 200);
       expect(result[1]['expense'], 100);
 
-      expect(result[2]['day'], formatter.format(fistOfCurrentMonth.add(const Duration(days: 2))));
+      expect(result[2]['day'],
+          formatter.format(fistOfCurrentMonth.add(const Duration(days: 2))));
       expect(result[2]['income'], 200);
       expect(result[2]['expense'], 0);
     });
@@ -235,44 +292,62 @@ void main() {
     test("currentMonthDailyTransactions single account", () async {
       await sossoldiDatabase.fillDemoData(countOfGeneratedTransaction: 2000);
 
-      try{
+      try {
         await db.transaction((txn) async {
           var batch = txn.batch();
           batch.delete(transactionTable);
           await batch.commit();
         });
-      } catch(error){
+      } catch (error) {
         throw Exception('DbBase.cleanDatabase: $error');
       }
 
-      const insertDemoTransactionsQuery = '''INSERT INTO `transaction` (date, amount, type, note, idCategory, idBankAccount, idBankAccountTransfer, recurring, idRecurringTransaction, createdAt, updatedAt) VALUES ''';
+      const insertDemoTransactionsQuery =
+          '''INSERT INTO `transaction` (date, amount, type, note, idCategory, idBankAccount, idBankAccountTransfer, recurring, idRecurringTransaction, createdAt, updatedAt) VALUES ''';
       final List<String> demoTransactions = [];
 
       final today = DateTime.now();
       final fistOfCurrentMonth = DateTime(today.year, today.month, 1);
 
       // Add a transaction of last month
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.subtract(const Duration(days: 10))));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth, idBankAccount: 71));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.subtract(const Duration(days: 10))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth, idBankAccount: 71));
 
       // Add transactions of current month
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth, idBankAccount: 71));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.add(const Duration(days: 1))));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.add(const Duration(days: 1)), amount: 200, type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth, idBankAccount: 71));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.add(const Duration(days: 2)), type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.add(const Duration(days: 2)), type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth, idBankAccount: 71));
+      demoTransactions
+          .add(createInsertSqlTransaction(date: fistOfCurrentMonth));
+      demoTransactions
+          .add(createInsertSqlTransaction(date: fistOfCurrentMonth));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth, idBankAccount: 71));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.add(const Duration(days: 1))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.add(const Duration(days: 1)),
+          amount: 200,
+          type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth, idBankAccount: 71));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.add(const Duration(days: 2)), type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.add(const Duration(days: 2)), type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth, idBankAccount: 71));
 
       // Add a transaction of next month
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth.add(const Duration(days: 32))));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentMonth, idBankAccount: 71));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth.add(const Duration(days: 32))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentMonth, idBankAccount: 71));
 
-      await db.execute("$insertDemoTransactionsQuery ${demoTransactions.join(",")};");
+      await db.execute(
+          "$insertDemoTransactionsQuery ${demoTransactions.join(",")};");
 
-      var result = await TransactionMethods().currentMonthDailyTransactions(accountId: 70);
+      var result = await TransactionMethods()
+          .currentMonthDailyTransactions(accountId: 70);
       expect(result.length, 3);
 
       final DateFormat formatter = DateFormat('yyyy-MM-dd');
@@ -281,11 +356,13 @@ void main() {
       expect(result[0]['income'], 0);
       expect(result[0]['expense'], 200);
 
-      expect(result[1]['day'], formatter.format(fistOfCurrentMonth.add(const Duration(days: 1))));
+      expect(result[1]['day'],
+          formatter.format(fistOfCurrentMonth.add(const Duration(days: 1))));
       expect(result[1]['income'], 200);
       expect(result[1]['expense'], 100);
 
-      expect(result[2]['day'], formatter.format(fistOfCurrentMonth.add(const Duration(days: 2))));
+      expect(result[2]['day'],
+          formatter.format(fistOfCurrentMonth.add(const Duration(days: 2))));
       expect(result[2]['income'], 200);
       expect(result[2]['expense'], 0);
     });
@@ -293,45 +370,63 @@ void main() {
     test("currentYearMontlyTransactions", () async {
       await sossoldiDatabase.fillDemoData(countOfGeneratedTransaction: 2000);
 
-      try{
+      try {
         await db.transaction((txn) async {
           var batch = txn.batch();
           batch.delete(transactionTable);
           await batch.commit();
         });
-      } catch(error){
+      } catch (error) {
         throw Exception('DbBase.cleanDatabase: $error');
       }
 
-      const insertDemoTransactionsQuery = '''INSERT INTO `transaction` (date, amount, type, note, idCategory, idBankAccount, idBankAccountTransfer, recurring, idRecurringTransaction, createdAt, updatedAt) VALUES ''';
+      const insertDemoTransactionsQuery =
+          '''INSERT INTO `transaction` (date, amount, type, note, idCategory, idBankAccount, idBankAccountTransfer, recurring, idRecurringTransaction, createdAt, updatedAt) VALUES ''';
       final List<String> demoTransactions = [];
 
       final today = DateTime.now();
       final fistOfCurrentYear = DateTime(today.year, 1, 1);
 
       // Add a transaction of last year
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.subtract(const Duration(days: 10))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.subtract(const Duration(days: 10))));
 
       // Add transactions of current year jan
       demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear));
       demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 1))));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 1)), amount: 200, type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 2)), type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 2)), type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 1))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 1)),
+          amount: 200,
+          type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 2)), type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 2)), type: 'IN'));
 
       // Add transactions of current year dec
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 300))));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 300))));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 301))));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 301)), amount: 500, type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 302)), type: 'IN'));
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 302)), type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 300))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 300))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 301))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 301)),
+          amount: 500,
+          type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 302)), type: 'IN'));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 302)), type: 'IN'));
 
       // Add a transaction of next year
-      demoTransactions.add(createInsertSqlTransaction(date: fistOfCurrentYear.add(const Duration(days: 400))));
+      demoTransactions.add(createInsertSqlTransaction(
+          date: fistOfCurrentYear.add(const Duration(days: 400))));
 
-      await db.execute("$insertDemoTransactionsQuery ${demoTransactions.join(",")};");
+      await db.execute(
+          "$insertDemoTransactionsQuery ${demoTransactions.join(",")};");
 
       var result = await TransactionMethods().currentYearMontlyTransactions();
       expect(result.length, 2);
@@ -342,13 +437,10 @@ void main() {
       expect(result[0]['income'], 400);
       expect(result[0]['expense'], 300);
 
-      expect(result[1]['month'], formatter.format(fistOfCurrentYear.add(const Duration(days: 300))));
+      expect(result[1]['month'],
+          formatter.format(fistOfCurrentYear.add(const Duration(days: 300))));
       expect(result[1]['income'], 700);
       expect(result[1]['expense'], 300);
     });
-
-
-
   });
-
 }


### PR DESCRIPTION
This PR add the functionality to duplicate a transaction from an existing one.

Steps to try it out:

- Go to a transaction page
- Click in the top left corner on the copy Icon
- Click "Duplicate" in the alert dialog

A new transaction with the exact same fields should be created with only a different `id` and a suffix `(copy)` in the note 

This PR also added a new test for the new functionality of the `.copy()` method.

- Closes #222 