### PR TITLE
Resolve #219: Add input formatter to allow one period, changes to keyboardType to show numpad on iOS

### DIFF
--- a/lib/pages/add_page/widgets/amount_widget.dart
+++ b/lib/pages/add_page/widgets/amount_widget.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -41,10 +42,24 @@ class _AmountWidgetState extends ConsumerState<AmountWidget> with Functions {
                 ),
               ),
         ),
-        keyboardType:
-            const TextInputType.numberWithOptions(decimal: true, signed: true),
+        keyboardType: TextInputType.numberWithOptions(
+          decimal: true,
+          // Leaving the default behaviour on Android which seems to be working as expeceted.
+          signed: defaultTargetPlatform == TargetPlatform.android,
+        ),
         inputFormatters: [
-          FilteringTextInputFormatter.allow(RegExp(r'\d*\.?\d{0,2}')),
+          FilteringTextInputFormatter.allow(
+            RegExp(r'\d*\.?\d{0,2}'),
+          ),
+          // AI generated regex: checks that the String contains one '.' only.
+          //
+          // Because replacementString is not nullable and defaults to empty String
+          // I've set it to the current input text so that every time a second period
+          // is inserted, it won't clear the text that's already present.
+          FilteringTextInputFormatter.allow(
+            RegExp(r'^[^.]*\.?[^.]*$'),
+            replacementString: widget.amountController.text,
+          ),
         ],
         autofocus: false,
         textAlign: TextAlign.center,

--- a/lib/pages/add_page/widgets/amount_widget.dart
+++ b/lib/pages/add_page/widgets/amount_widget.dart
@@ -48,18 +48,22 @@ class _AmountWidgetState extends ConsumerState<AmountWidget> with Functions {
           signed: defaultTargetPlatform == TargetPlatform.android,
         ),
         inputFormatters: [
-          FilteringTextInputFormatter.allow(
-            RegExp(r'\d*\.?\d{0,2}'),
-          ),
-          // AI generated regex: checks that the String contains one '.' only.
+          // Allow only digits and one decimal separator.
+          FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+
+          // AI generated regex: checks that the String contains either one comma or
+          // one period. Only two decimal digits only allowed.
           //
           // Because replacementString is not nullable and defaults to empty String
           // I've set it to the current input text so that every time a second period
           // is inserted, it won't clear the text that's already present.
           FilteringTextInputFormatter.allow(
-            RegExp(r'^[^.]*\.?[^.]*$'),
+            RegExp(r'^(\d*([.,]\d{0,2})?|[.,]\d{0,2})$'),
             replacementString: widget.amountController.text,
           ),
+
+          // Replaces comma with period.
+          FilteringTextInputFormatter.deny(RegExp(r','), replacementString: '.'),
         ],
         autofocus: false,
         textAlign: TextAlign.center,

--- a/lib/pages/more_info_page/collaborators_page.dart
+++ b/lib/pages/more_info_page/collaborators_page.dart
@@ -72,7 +72,12 @@ var collaborators = const [
     "napitek",
     "Full Stack Dev",
     "github.com/napitek",
-  ]
+  ],
+  [
+    "Alessandro Bongiovanni",
+    "Flutter Dev",
+    "https://github.com/bongio94",
+  ],
 ];
 
 class _CollaboratorsPageState extends ConsumerState<CollaboratorsPage> {

--- a/lib/pages/more_info_page/collaborators_page.dart
+++ b/lib/pages/more_info_page/collaborators_page.dart
@@ -76,7 +76,7 @@ var collaborators = const [
   [
     "Alessandro Bongiovanni",
     "Flutter Dev",
-    "https://github.com/bongio94",
+    "github.com/bongio94",
   ],
 ];
 

--- a/test/widget/amount_widget_test.dart
+++ b/test/widget/amount_widget_test.dart
@@ -6,7 +6,7 @@ import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 void main() {
   // I'm not 100% familiar with how this works but for some reason when adding the last two test cases
-  // it would throw and error after the tests were completed successfully.
+  // it would throw an error after the tests were completed successfully.
   //
   // Seems like using the NoIsolate solves the problem.
   databaseFactory = databaseFactoryFfiNoIsolate;

--- a/test/widget/amount_widget_test.dart
+++ b/test/widget/amount_widget_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/pages/add_page/widgets/amount_widget.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  databaseFactory = databaseFactoryFfi;
+  testWidgets(
+    'GIVEN an AmountWidget widget '
+    'WHEN a period character is inserted '
+    'THEN the period character can be found',
+    (WidgetTester tester) async {
+      const amountWidgetKey = Key('amountWidgetKey');
+      const numberWithOnePeriod = "10.1";
+
+      final amountController = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ProviderScope(
+              child: AmountWidget(
+                amountController,
+                key: amountWidgetKey,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final findAmountWidget = find.byKey(amountWidgetKey);
+      expect(findAmountWidget, findsOneWidget);
+
+      await tester.tap(findAmountWidget);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(findAmountWidget, numberWithOnePeriod);
+
+      final findPeriod = find.textContaining('.');
+      expect(findPeriod, findsOne);
+      expect(amountController.text, equals(numberWithOnePeriod));
+    },
+  );
+
+  testWidgets(
+    'GIVEN an AmountWidget widget '
+    'WHEN more than one period characters are inserted '
+    'THEN no text is found',
+    (WidgetTester tester) async {
+      const amountWidgetKey = Key('amountWidgetKey');
+      const numberWithTwoPeriods = "10.1.2";
+
+      final amountController = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ProviderScope(
+              child: AmountWidget(
+                amountController,
+                key: amountWidgetKey,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final findAmountWidget = find.byKey(amountWidgetKey);
+      expect(findAmountWidget, findsOneWidget);
+
+      await tester.tap(findAmountWidget);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(findAmountWidget, numberWithTwoPeriods);
+
+      final findPeriod = find.textContaining('.');
+      expect(findPeriod, findsNothing);
+      expect(amountController.text.isEmpty, isTrue);
+    },
+  );
+}

--- a/test/widget/amount_widget_test.dart
+++ b/test/widget/amount_widget_test.dart
@@ -5,29 +5,40 @@ import 'package:sossoldi/pages/add_page/widgets/amount_widget.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 void main() {
-  databaseFactory = databaseFactoryFfi;
+  // I'm not 100% familiar with how this works but for some reason when adding the last two test cases
+  // it would throw and error after the tests were completed successfully.
+  //
+  // Seems like using the NoIsolate solves the problem.
+  databaseFactory = databaseFactoryFfiNoIsolate;
+
+  const amountWidgetKey = Key('amountWidgetKey');
+  var amountController = TextEditingController();
+
+  setUp(() {
+    amountController = TextEditingController();
+  });
+
+  Widget amountWidget() {
+    return MaterialApp(
+      home: Material(
+        child: ProviderScope(
+          child: AmountWidget(
+            amountController,
+            key: amountWidgetKey,
+          ),
+        ),
+      ),
+    );
+  }
+
   testWidgets(
     'GIVEN an AmountWidget widget '
     'WHEN a period character is inserted '
     'THEN the period character can be found',
     (WidgetTester tester) async {
-      const amountWidgetKey = Key('amountWidgetKey');
       const numberWithOnePeriod = "10.1";
 
-      final amountController = TextEditingController();
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: ProviderScope(
-              child: AmountWidget(
-                amountController,
-                key: amountWidgetKey,
-              ),
-            ),
-          ),
-        ),
-      );
+      await tester.pumpWidget(amountWidget());
 
       final findAmountWidget = find.byKey(amountWidgetKey);
       expect(findAmountWidget, findsOneWidget);
@@ -48,23 +59,9 @@ void main() {
     'WHEN more than one period characters are inserted '
     'THEN no text is found',
     (WidgetTester tester) async {
-      const amountWidgetKey = Key('amountWidgetKey');
       const numberWithTwoPeriods = "10.1.2";
 
-      final amountController = TextEditingController();
-
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: ProviderScope(
-              child: AmountWidget(
-                amountController,
-                key: amountWidgetKey,
-              ),
-            ),
-          ),
-        ),
-      );
+      await tester.pumpWidget(amountWidget());
 
       final findAmountWidget = find.byKey(amountWidgetKey);
       expect(findAmountWidget, findsOneWidget);
@@ -73,6 +70,57 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.enterText(findAmountWidget, numberWithTwoPeriods);
+
+      final findPeriod = find.textContaining('.');
+      expect(findPeriod, findsNothing);
+      expect(amountController.text.isEmpty, isTrue);
+    },
+  );
+
+  testWidgets(
+    'GIVEN an AmountWidget widget '
+    'WHEN a comma is used instead of a period '
+    'THEN the comma is replaced with a period',
+    (WidgetTester tester) async {
+      const numberWithComma = "10,1";
+
+      await tester.pumpWidget(amountWidget());
+
+      final findAmountWidget = find.byKey(amountWidgetKey);
+      expect(findAmountWidget, findsOneWidget);
+
+      await tester.tap(findAmountWidget);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(findAmountWidget, numberWithComma);
+
+      final findPeriod = find.textContaining('.');
+      expect(findPeriod, findsOneWidget);
+      expect(
+        amountController.text,
+        equals(
+          numberWithComma.replaceAll(',', '.'),
+        ),
+      );
+    },
+  );
+
+  testWidgets(
+    'GIVEN an AmountWidget widget '
+    'WHEN a number with more than two decimal digits is used '
+    'THEN the number is not allowed',
+    (WidgetTester tester) async {
+      const numberWithThreeDecimals = "10.123";
+
+      await tester.pumpWidget(amountWidget());
+
+      final findAmountWidget = find.byKey(amountWidgetKey);
+      expect(findAmountWidget, findsOneWidget);
+
+      await tester.tap(findAmountWidget);
+      await tester.pumpAndSettle();
+
+      await tester.enterText(findAmountWidget, numberWithThreeDecimals);
 
       final findPeriod = find.textContaining('.');
       expect(findPeriod, findsNothing);


### PR DESCRIPTION
In this PR:

- b8f59020541a7499bfedf915b0c5a881b18101e3: 
    - Updated `keyboardType` to have the `signed` property `true` only when running on Android. This allows to show the numpad on iOS as well.
    - Added a new `FilteringTextInputFormatter` which allows for one period only to be entered in the `TextField`.
- 58b1501575e4fb02d9854720567273636870542a: Added two tests for the `AmountWidget` widget to check that only single period are allowed in the `TextField`.

Resolve #219 
