### PR TITLE
feat: Resolve #200 - Added confirmation dialog when deleting an account

### DIFF
--- a/lib/custom_widgets/native_alert_dialog.dart
+++ b/lib/custom_widgets/native_alert_dialog.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+/// An alert dialog with the native look and feel.
+///
+/// It uses [Platform] to check whether to return an iOS or an Android dialog.
+///
+/// The Android variant uses [AlertDialog] while the iOS variant uses [CupertinoAlertDialog].
+///
+/// Being the actions used in dialogs quite different between the two platforms, the [actions] property maps to the
+/// appropriate widget, [TextButton] on Android and [CupertinoDialogAction] on iOS.
+class AdaptiveDialog extends StatelessWidget {
+  /// [List] of actions, mapped to [TextButton] on Android and to [CupertinoDialogAction] on iOS.
+  final List<AdaptiveDialogAction>? actions;
+
+  /// The title of the dialog.
+  final Widget? title;
+
+  /// The content of the dialog.
+  final Widget? content;
+
+  const AdaptiveDialog({
+    super.key,
+    this.actions,
+    this.title,
+    this.content,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Platform.isAndroid
+        ? _AndroidDialog(actions: actions, title: title, content: content)
+        : _CupertinoDialog(actions: actions, title: title, content: content);
+  }
+}
+
+/// A convenience class for a generic dialog action.
+///
+/// Used to map a generic action to the platform specific Widget.
+class AdaptiveDialogAction {
+  /// The child of the action, usually a [Text].
+  final Widget child;
+
+  /// Callback to be executed when the action is pressed.
+  final VoidCallback? onPressed;
+
+  /// Only used on iOS. When `true` the action [Text] will be [CupertinoColors.systemRed].
+  final bool isDestructiveAction;
+
+  /// Only used on iOS. When `true` the action [Text] will be bold.
+  final bool isDefaultAction;
+
+  AdaptiveDialogAction({
+    required this.child,
+    this.onPressed,
+    this.isDestructiveAction = false,
+    this.isDefaultAction = false,
+  });
+}
+
+class _AndroidDialog extends StatelessWidget {
+  final List<AdaptiveDialogAction>? actions;
+  final Widget? title;
+  final Widget? content;
+
+  const _AndroidDialog({
+    this.actions,
+    this.title,
+    this.content,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: title,
+      content: content,
+      actions: actions != null
+          ? actions!
+              .map(
+                (action) => TextButton(
+                  onPressed: action.onPressed,
+                  child: action.child,
+                ),
+              )
+              .toList()
+          : [],
+    );
+  }
+}
+
+class _CupertinoDialog extends StatelessWidget {
+  final List<AdaptiveDialogAction>? actions;
+  final Widget? title;
+  final Widget? content;
+
+  const _CupertinoDialog({
+    this.actions,
+    this.title,
+    this.content,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoAlertDialog(
+      title: title,
+      content: content,
+      actions: actions != null
+          ? actions!
+              .map(
+                (action) => CupertinoDialogAction(
+                  isDestructiveAction: action.isDestructiveAction,
+                  isDefaultAction: action.isDefaultAction,
+                  onPressed: action.onPressed,
+                  child: action.child,
+                ),
+              )
+              .toList()
+          : [],
+    );
+  }
+}

--- a/lib/pages/accounts/add_account.dart
+++ b/lib/pages/accounts/add_account.dart
@@ -7,6 +7,7 @@ import '../../constants/constants.dart';
 import '../../constants/functions.dart';
 import '../../constants/style.dart';
 import '../../providers/currency_provider.dart';
+import 'widgets/confirm_account_deletion_dialog.dart';
 
 class AddAccount extends ConsumerStatefulWidget {
   const AddAccount({super.key});
@@ -357,14 +358,30 @@ class _AddAccountState extends ConsumerState<AddAccount> with Functions {
                       width: double.infinity,
                       padding: const EdgeInsets.all(16),
                       child: TextButton.icon(
-                        onPressed: () => ref
-                            .read(accountsProvider.notifier)
-                            .removeAccount(selectedAccount.id!)
-                            .whenComplete(() {
-                          if (context.mounted) {
-                            Navigator.of(context).pop();
-                          }
-                        }),
+                        onPressed: () {
+                          showDialog(
+                            context: context,
+                            builder: (context) {
+                              return ConfirmAccountDeletionDialog(
+                                account: selectedAccount,
+                                onPressed: () => ref
+                                    .read(accountsProvider.notifier)
+                                    .removeAccount(selectedAccount.id!)
+                                    .whenComplete(
+                                  () {
+                                    if (context.mounted) {
+                                      // Navigate back to the /account-list route.
+                                      Navigator.popUntil(
+                                        context,
+                                        ModalRoute.withName('/account-list'),
+                                      );
+                                    }
+                                  },
+                                ),
+                              );
+                            },
+                          );
+                        },
                         style: TextButton.styleFrom(
                           side: const BorderSide(color: red, width: 1),
                         ),

--- a/lib/pages/accounts/widgets/confirm_account_deletion_dialog.dart
+++ b/lib/pages/accounts/widgets/confirm_account_deletion_dialog.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import '../../../custom_widgets/native_alert_dialog.dart';
+import '../../../model/bank_account.dart';
+
+class ConfirmAccountDeletionDialog extends StatelessWidget {
+  final BankAccount account;
+  final VoidCallback onPressed;
+
+  const ConfirmAccountDeletionDialog({
+    required this.account,
+    required this.onPressed,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveDialog(
+      title: Text('Delete account'),
+      content: Text(
+          'Are you sure you want to delete the account named "${account.name}"?\n\nThis action cannot be undone.'),
+      actions: [
+        AdaptiveDialogAction(
+          child: Text('Cancel'),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+        AdaptiveDialogAction(
+          child: Text('Delete'),
+          isDestructiveAction: true,
+          onPressed: onPressed,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -78,6 +78,7 @@ class AppTheme {
         ),
         textStyle: WidgetStatePropertyAll(
           TextStyle(
+            fontFamily: 'NunitoSans',
             fontSize: 14.0,
             fontWeight: FontWeight.w700,
           ),
@@ -246,6 +247,7 @@ class AppTheme {
         ),
         textStyle: WidgetStatePropertyAll(
           TextStyle(
+            fontFamily: 'NunitoSans',
             fontSize: 14.0,
             fontWeight: FontWeight.w700,
           ),

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -53,7 +53,7 @@ class AppTheme {
         shape: WidgetStatePropertyAll(
           RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
-        textStyle: WidgetStatePropertyAll(
+        textStyle: const WidgetStatePropertyAll(
           TextStyle(
             fontFamily: 'NunitoSans',
             fontSize: 18.0,
@@ -221,7 +221,7 @@ class AppTheme {
         shape: WidgetStatePropertyAll(
           RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
-        textStyle: WidgetStatePropertyAll(
+        textStyle: const WidgetStatePropertyAll(
           TextStyle(
             fontFamily: 'NunitoSans',
             fontSize: 18.0,

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -53,8 +53,9 @@ class AppTheme {
         shape: WidgetStatePropertyAll(
           RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
-        textStyle: const WidgetStatePropertyAll(
+        textStyle: WidgetStatePropertyAll(
           TextStyle(
+            fontFamily: 'NunitoSans',
             fontSize: 18.0,
             fontWeight: FontWeight.w600,
           ),
@@ -220,8 +221,9 @@ class AppTheme {
         shape: WidgetStatePropertyAll(
           RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
-        textStyle: const WidgetStatePropertyAll(
+        textStyle: WidgetStatePropertyAll(
           TextStyle(
+            fontFamily: 'NunitoSans',
             fontSize: 18.0,
             fontWeight: FontWeight.w600,
           ),

--- a/test/widget/native_alert_dialog_widget_test.dart
+++ b/test/widget/native_alert_dialog_widget_test.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/custom_widgets/native_alert_dialog.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  databaseFactory = databaseFactoryFfi;
+
+  const adaptiveDialogKey = Key('adaptiveDialogKey');
+  const buttonLabel = 'Label';
+  const firstAction = 'First';
+  const secondAction = 'Second';
+
+  var completer = Completer<void>();
+
+  setUp(() {
+    completer = Completer<void>();
+  });
+
+  Widget buildDialog() {
+    return Builder(
+      builder: (context) {
+        return TextButton(
+          child: Text(buttonLabel),
+          onPressed: () {
+            showDialog(
+              context: context,
+              builder: (context) {
+                return AdaptiveDialog(
+                  key: adaptiveDialogKey,
+                  actions: [
+                    AdaptiveDialogAction(
+                      child: Text(firstAction),
+                      onPressed: completer.complete,
+                    ),
+                    AdaptiveDialogAction(
+                      child: Text(secondAction),
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                      },
+                    ),
+                  ],
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+
+  testWidgets(
+    'GIVEN an AdaptiveDialog widget '
+    'WHEN the dialog is shown '
+    'THEN it can be found through its key',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ProviderScope(
+              child: buildDialog(),
+            ),
+          ),
+        ),
+      );
+
+      final findButton = find.text(buttonLabel);
+      expect(findButton, findsOneWidget);
+
+      await tester.tap(findButton);
+      await tester.pumpAndSettle();
+
+      final findDialogByKey = find.byKey(adaptiveDialogKey);
+      expect(findDialogByKey, findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'GIVEN an AdaptiveDialog widget '
+    'WHEN the dialog is shown '
+    'AND a button is tapped '
+    'THEN the completer completes',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ProviderScope(
+              child: buildDialog(),
+            ),
+          ),
+        ),
+      );
+
+      final findButton = find.text(buttonLabel);
+      expect(findButton, findsOneWidget);
+
+      await tester.tap(findButton);
+      await tester.pumpAndSettle();
+
+      final findFirstAction = find.text(firstAction);
+      expect(findFirstAction, findsOneWidget);
+
+      expect(completer.isCompleted, isFalse);
+      await tester.tap(findFirstAction);
+      expect(completer.isCompleted, isTrue);
+    },
+  );
+
+  testWidgets(
+    'GIVEN an AdaptiveDialog widget '
+    'WHEN the dialog is shown '
+    'AND a pop is invoked '
+    'THEN the dialog route is popped',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: ProviderScope(
+              child: buildDialog(),
+            ),
+          ),
+        ),
+      );
+
+      final findButton = find.text(buttonLabel);
+      expect(findButton, findsOneWidget);
+
+      await tester.tap(findButton);
+      await tester.pumpAndSettle();
+
+      final findSecondAction = find.text(secondAction);
+      expect(findSecondAction, findsOneWidget);
+
+      await tester.tap(findSecondAction);
+      await tester.pumpAndSettle();
+
+      final findDialog = find.byKey(adaptiveDialogKey);
+      expect(findDialog, findsNothing);
+    },
+  );
+}


### PR DESCRIPTION
In this PR:

- Added a new widget, `AdaptiveDialog`:
This was done for having a convenient way of displaying a native looking dialog. The problem with `AlertDialog.adaptive` is that you still need to differentiate the actions, otherwise you'll end up with Material buttons on the Cupertino widgets. To simplify this process I've create a convenience class for the actions, which will be mapped to the correct platform widget (`TextButton` on Android, `CupertinoDialogAction` on iOS).

- Added the confirmation dialog:
When tapping on the _Delete account_ button you'll now see a dialog which will ask you to confirm your choice. I don't know if the wording on the dialog can be improved, it looked good enough for me but I'm open to suggestions.

- After the account has been deleted, navigate back to the `'/account-list'` route.

- Created the widgets folder in `lib/pages/accounts` and added the `ConfirmAccountDeletionDialog`.

- `TextButton` now uses the _NunitoSans_ font:
Please let me know if using _Roboto_ was a design choice. If not, by specifying the `fontFamily` in the `Theme` there's no need of assigning a `textTheme` to each `Text` in `TextButton` (unless you want to use a different `textTheme` than the default one of course).

- Added some basic tests for the `AdaptiveDialog` widget.


| | Light mode | Dark mode |
|-|------------|-----------|
| Android |![Screenshot_1741992130](https://github.com/user-attachments/assets/ce069aee-917c-4c47-af63-8113613a839f) |![Screenshot_1741992120](https://github.com/user-attachments/assets/3d3172ac-5e95-4c3c-a568-97c8782558d3) |
| iOS |![Simulator Screenshot - iPhone 16 Pro - 2025-03-14 at 23 41 40](https://github.com/user-attachments/assets/f64d7d70-802d-4dcc-aea1-859fe0fb0b9b) |![Simulator Screenshot - iPhone 16 Pro - 2025-03-14 at 23 41 52](https://github.com/user-attachments/assets/c6673b07-5abd-453e-aa35-534146da58e7) |

Resolve #200 

