### PR TITLE
fix: Resolve #249, #264 - Updated CupertinoDatePicker background color

### DIFF
--- a/lib/pages/add_page/add_page.dart
+++ b/lib/pages/add_page/add_page.dart
@@ -325,8 +325,7 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
                                 builder: (_) => Container(
                                   height: 300,
                                   color: CupertinoDynamicColor.resolve(
-                                    CupertinoTheme.of(context)
-                                        .scaffoldBackgroundColor,
+                                    CupertinoColors.secondarySystemBackground,
                                     context,
                                   ),
                                   child: CupertinoDatePicker(

--- a/lib/pages/add_page/add_page.dart
+++ b/lib/pages/add_page/add_page.dart
@@ -324,7 +324,11 @@ class _AddPageState extends ConsumerState<AddPage> with Functions {
                                 context: context,
                                 builder: (_) => Container(
                                   height: 300,
-                                  color: white,
+                                  color: CupertinoDynamicColor.resolve(
+                                    CupertinoTheme.of(context)
+                                        .scaffoldBackgroundColor,
+                                    context,
+                                  ),
                                   child: CupertinoDatePicker(
                                     initialDateTime: ref.watch(dateProvider),
                                     minimumYear: 2015,

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -5,8 +5,9 @@ import '../constants/style.dart';
 
 class AppTheme {
   static final lightTheme = ThemeData(
-    cupertinoOverrideTheme:
-        const CupertinoThemeData(brightness: Brightness.light),
+    cupertinoOverrideTheme: const CupertinoThemeData(
+      brightness: Brightness.light,
+    ),
     colorScheme: customColorScheme,
     scaffoldBackgroundColor: white,
     appBarTheme: const AppBarTheme(

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -1,9 +1,11 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../constants/style.dart';
 
 class AppTheme {
   static final lightTheme = ThemeData(
+    cupertinoOverrideTheme: const CupertinoThemeData(brightness: Brightness.light),
     colorScheme: customColorScheme,
     scaffoldBackgroundColor: white,
     appBarTheme: const AppBarTheme(
@@ -170,6 +172,7 @@ class AppTheme {
   );
 
   static final darkTheme = ThemeData(
+    cupertinoOverrideTheme: const CupertinoThemeData(brightness: Brightness.dark),
     colorScheme: darkCustomColorScheme,
     scaffoldBackgroundColor: darkGrey4,
     appBarTheme: const AppBarTheme(

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -5,7 +5,8 @@ import '../constants/style.dart';
 
 class AppTheme {
   static final lightTheme = ThemeData(
-    cupertinoOverrideTheme: const CupertinoThemeData(brightness: Brightness.light),
+    cupertinoOverrideTheme:
+        const CupertinoThemeData(brightness: Brightness.light),
     colorScheme: customColorScheme,
     scaffoldBackgroundColor: white,
     appBarTheme: const AppBarTheme(
@@ -172,7 +173,9 @@ class AppTheme {
   );
 
   static final darkTheme = ThemeData(
-    cupertinoOverrideTheme: const CupertinoThemeData(brightness: Brightness.dark),
+    cupertinoOverrideTheme: const CupertinoThemeData(
+      brightness: Brightness.dark,
+    ),
     colorScheme: darkCustomColorScheme,
     scaffoldBackgroundColor: darkGrey4,
     appBarTheme: const AppBarTheme(


### PR DESCRIPTION
In this PR:

- Added `cupertinoOverrideTheme` for the `AppTheme`

- Updated the background color of the `CupertinoDatePicker`'s `Container` to [secondarySystemBackground](https://api.flutter.dev/flutter/cupertino/CupertinoColors/secondarySystemBackground-constant.html), so that it has contrast in dark mode.

![Simulator Screenshot - iPhone 16 Pro - 2025-03-15 at 01 13 57](https://github.com/user-attachments/assets/55a9c84b-21cb-40e0-b381-3f9c69ea5c70)


Resolve #249, #264 (duplicate)
