### PR TITLE
Added category type icon ( import/export ) on category list

### DIFF
--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -29,6 +29,12 @@ const Map<String, IconData> accountIconList = {
   'account_balance': Icons.account_balance,
 };
 
+const Map<String, IconData> genericIconList = {
+  'import': Icons.arrow_downward,
+  'export': Icons.arrow_upward,
+  'unknown': Icons.question_mark
+};
+
 // colors
 const categoryColorList = [
   category1,

--- a/lib/custom_widgets/rounded_icon.dart
+++ b/lib/custom_widgets/rounded_icon.dart
@@ -6,6 +6,7 @@ class RoundedIcon extends StatelessWidget {
   const RoundedIcon({
     this.icon,
     this.backgroundColor,
+    this.color,
     this.size = 24,
     this.padding = const EdgeInsets.all(10.0),
     super.key,
@@ -13,6 +14,7 @@ class RoundedIcon extends StatelessWidget {
 
   final IconData? icon;
   final Color? backgroundColor;
+  final Color? color;
   final double? size;
   final EdgeInsets? padding;
 
@@ -28,7 +30,7 @@ class RoundedIcon extends StatelessWidget {
           ? Icon(
               icon,
               size: size,
-              color: white,
+              color: color ?? white,
             )
           : const SizedBox(),
     );

--- a/lib/pages/categories/category_list.dart
+++ b/lib/pages/categories/category_list.dart
@@ -16,6 +16,29 @@ class CategoryList extends ConsumerStatefulWidget {
 }
 
 class _CategoryListState extends ConsumerState<CategoryList> with Functions {
+  Widget getCategoryTypeIcon(String categoryTypeName) {
+    switch (categoryTypeName) {
+      case 'expense':
+        return RoundedIcon(
+          icon: genericIconList['export'],
+          color: Theme.of(context).colorScheme.primary,
+          size: 25,
+        );
+      case 'income':
+        return RoundedIcon(
+          icon: genericIconList['import'],
+          color: Theme.of(context).colorScheme.primary,
+          size: 25,
+        );
+      default:
+        return RoundedIcon(
+          icon: genericIconList['unknown'],
+          color: Theme.of(context).colorScheme.primary,
+          size: 25,
+        );
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final categorysList = ref.watch(categoriesProvider);
@@ -101,6 +124,8 @@ class _CategoryListState extends ConsumerState<CategoryList> with Functions {
                               .copyWith(
                                   color: Theme.of(context).colorScheme.primary),
                         ),
+                        const Spacer(),
+                        getCategoryTypeIcon(category.type.name),
                       ],
                     ),
                   );


### PR DESCRIPTION
Added the category type icon ( income/expense) to the end of the category row.
In addition I modified the RoundedIcon component by adding the optional color property that as a fallback uses white.
![image](https://github.com/user-attachments/assets/bf342b6d-79ba-4276-a2ac-1db8fdd8a7e9)
![image](https://github.com/user-attachments/assets/3c0d28f2-963d-4d34-ac0c-2fa1ca22c208)

