### PR TITLE
chore: Resolve #243 - Improve platform specific UI elements and route transitions

### DIFF
--- a/lib/pages/accounts/add_account.dart
+++ b/lib/pages/accounts/add_account.dart
@@ -298,9 +298,7 @@ class _AddAccountState extends ConsumerState<AddAccount> with Functions {
                               RegExp(r'^\d*\.?\d{0,2}'),
                             ),
                           ],
-                          style: Theme.of(context)
-                              .textTheme
-                              .titleLarge,
+                          style: Theme.of(context).textTheme.titleLarge,
                         ),
                       ],
                     ),
@@ -327,7 +325,7 @@ class _AddAccountState extends ConsumerState<AddAccount> with Functions {
                                 "Set as main account",
                                 style: Theme.of(context).textTheme.bodyLarge,
                               ),
-                              CupertinoSwitch(
+                              Switch.adaptive(
                                 value: mainAccount,
                                 onChanged: (value) =>
                                     setState(() => mainAccount = value),
@@ -345,7 +343,7 @@ class _AddAccountState extends ConsumerState<AddAccount> with Functions {
                                 "Counts for the net worth",
                                 style: Theme.of(context).textTheme.bodyLarge,
                               ),
-                              CupertinoSwitch(
+                              Switch.adaptive(
                                 value: countNetWorth,
                                 onChanged: (value) =>
                                     setState(() => countNetWorth = value),

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -26,54 +28,65 @@ import 'pages/backup_page/backup_page.dart';
 Route<dynamic> makeRoute(RouteSettings settings) {
   switch (settings.name) {
     case '/':
-      return _materialPageRoute(settings.name, const Structure());
+      return buildAdaptiveRoute(settings.name, const Structure());
     case '/onboarding':
-      return _materialPageRoute(settings.name, const Onboarding());
+      return buildAdaptiveRoute(settings.name, const Onboarding());
     case '/dashboard':
-      return _materialPageRoute(settings.name, const HomePage());
+      return buildAdaptiveRoute(settings.name, const HomePage());
     case '/add-page':
       final args = settings.arguments as Map<String, dynamic>?;
-      return _materialPageRoute(
+      return buildAdaptiveRoute(
         settings.name,
-        AddPage(recurrencyEditingPermitted: args?['recurrencyEditingPermitted'] ?? true),
+        AddPage(
+            recurrencyEditingPermitted:
+                args?['recurrencyEditingPermitted'] ?? true),
       );
     case '/edit-recurring-transaction':
-      return _materialPageRoute(settings.name, const EditRecurringTransaction());
+      return buildAdaptiveRoute(
+          settings.name, const EditRecurringTransaction());
     case '/transactions':
-      return _materialPageRoute(settings.name, const TransactionsPage());
+      return buildAdaptiveRoute(settings.name, const TransactionsPage());
     case '/category-list':
-      return _cupertinoPageRoute(settings.name, const CategoryList());
+      return buildAdaptiveRoute(settings.name, const CategoryList());
     case '/add-category':
-      return _cupertinoPageRoute(settings.name, const AddCategory());
+      return buildAdaptiveRoute(settings.name, const AddCategory());
     case '/more-info':
-      return _cupertinoPageRoute(settings.name, const MoreInfoPage());
+      return buildAdaptiveRoute(settings.name, const MoreInfoPage());
     case '/privacy-policy':
-      return _cupertinoPageRoute(settings.name, const PrivacyPolicyPage());
+      return buildAdaptiveRoute(settings.name, const PrivacyPolicyPage());
     case '/collaborators':
-      return _cupertinoPageRoute(settings.name, const CollaboratorsPage());
+      return buildAdaptiveRoute(settings.name, const CollaboratorsPage());
     case '/account':
-      return _materialPageRoute(settings.name, const AccountPage());
+      return buildAdaptiveRoute(settings.name, const AccountPage());
     case '/account-list':
-      return _cupertinoPageRoute(settings.name, const AccountList());
+      return buildAdaptiveRoute(settings.name, const AccountList());
     case '/add-account':
-      return _cupertinoPageRoute(settings.name, const AddAccount());
+      return buildAdaptiveRoute(settings.name, const AddAccount());
     case '/planning':
-      return _materialPageRoute(settings.name, const PlanningPage());
+      return buildAdaptiveRoute(settings.name, const PlanningPage());
     case '/graphs':
-      return _materialPageRoute(settings.name, const GraphsPage());
+      return buildAdaptiveRoute(settings.name, const GraphsPage());
     case '/settings':
-      return _cupertinoPageRoute(settings.name, const SettingsPage());
+      return buildAdaptiveRoute(settings.name, const SettingsPage());
     case '/general-settings':
-      return _cupertinoPageRoute(settings.name, const GeneralSettingsPage());
+      return buildAdaptiveRoute(settings.name, const GeneralSettingsPage());
     case '/notifications-settings':
-      return _cupertinoPageRoute(settings.name, const NotificationsSettings());
+      return buildAdaptiveRoute(settings.name, const NotificationsSettings());
     case '/search':
-      return _materialPageRoute(settings.name, const SearchPage());
+      return buildAdaptiveRoute(settings.name, const SearchPage());
     case '/backup-page':
-      return _cupertinoPageRoute(settings.name, const BackupPage());
+      return buildAdaptiveRoute(settings.name, const BackupPage());
     default:
       throw 'Route is not defined';
   }
+}
+
+PageRoute buildAdaptiveRoute(String? routeName, Widget viewToShow) {
+  if (Platform.isAndroid) {
+    return _materialPageRoute(routeName, viewToShow);
+  }
+
+  return _cupertinoPageRoute(routeName, viewToShow);
 }
 
 PageRoute _cupertinoPageRoute(String? routeName, Widget viewToShow) {

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -104,6 +104,35 @@ class AppTheme {
       contentPadding: EdgeInsets.all(16),
     ),
     disabledColor: grey2,
+    switchTheme: SwitchThemeData(
+      trackOutlineColor: WidgetStateColor.resolveWith(
+        (state) {
+          if (state.contains(WidgetState.selected)) {
+            return customColorScheme.secondary;
+          }
+
+          return grey1;
+        },
+      ),
+      thumbColor: WidgetStateColor.resolveWith(
+        (state) {
+          if (state.contains(WidgetState.selected)) {
+            return customColorScheme.surface;
+          }
+
+          return grey1;
+        },
+      ),
+      trackColor: WidgetStateColor.resolveWith(
+        (state) {
+          if (state.contains(WidgetState.selected)) {
+            return customColorScheme.secondary;
+          }
+
+          return grey3;
+        },
+      ),
+    ),
     fontFamily: 'NunitoSans',
     textTheme: const TextTheme(
       // display
@@ -278,6 +307,35 @@ class AppTheme {
     ),
 
     disabledColor: darkGrey2,
+    switchTheme: SwitchThemeData(
+      trackOutlineColor: WidgetStateColor.resolveWith(
+        (state) {
+          if (state.contains(WidgetState.selected)) {
+            return darkCustomColorScheme.secondary;
+          }
+
+          return darkGrey1;
+        },
+      ),
+      thumbColor: WidgetStateColor.resolveWith(
+        (state) {
+          if (state.contains(WidgetState.selected)) {
+            return darkCustomColorScheme.surface;
+          }
+
+          return darkGrey1;
+        },
+      ),
+      trackColor: WidgetStateColor.resolveWith(
+        (state) {
+          if (state.contains(WidgetState.selected)) {
+            return darkCustomColorScheme.secondary;
+          }
+
+          return darkGrey3;
+        },
+      ),
+    ),
     //Text style
     fontFamily: 'NunitoSans',
     textTheme: const TextTheme(

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -5,6 +5,7 @@ import '../constants/style.dart';
 
 class AppTheme {
   static final lightTheme = ThemeData(
+    adaptations: [SwitchThemeAdaptation()],
     cupertinoOverrideTheme: const CupertinoThemeData(
       brightness: Brightness.light,
     ),
@@ -206,6 +207,7 @@ class AppTheme {
   );
 
   static final darkTheme = ThemeData(
+    adaptations: [SwitchThemeAdaptation()],
     cupertinoOverrideTheme: const CupertinoThemeData(
       brightness: Brightness.dark,
     ),
@@ -449,3 +451,27 @@ ColorScheme darkCustomColorScheme = const ColorScheme(
   onError: darkBlack,
   brightness: Brightness.dark,
 );
+
+class SwitchThemeAdaptation extends Adaptation<SwitchThemeData> {
+  const SwitchThemeAdaptation();
+
+  @override
+  SwitchThemeData adapt(ThemeData theme, SwitchThemeData defaultValue) {
+    switch (theme.platform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        return defaultValue;
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        return SwitchThemeData(
+          trackColor: WidgetStateProperty.fromMap(
+            {
+              WidgetState.selected: theme.colorScheme.secondary,
+            },
+          ),
+        );
+    }
+  }
+}


### PR DESCRIPTION
Copy of #301 

In this PR:

- Replaced `CupertinoSwitch` with `Switch.adaptive` in `lib/pages/accounts/add_account.dart`.
- Added `SwitchThemeData`:
  - @federicopozzato probably worth to have a look at the colors, feel free to suggest changes. 
  You can find more info on the [Material3 Switch guidance](https://m3.material.io/components/switch/overview).
- Created the `buildAdaptiveRoute` wrapper function for `_materialPageRoute` and `_cupertinoPageRoute` in `lib/routes.dart`. This ensure that a Material route is used on Android and a Cupertino route is used on iOS. 
It might give conflicts with #295 and #290.

|LightMode|DarkMode|
|-----------|-----------|
|![Screenshot_1742060920](https://github.com/user-attachments/assets/bd65bc80-781d-4b5c-a0b6-de9b3128071c)|![Screenshot_1742060907](https://github.com/user-attachments/assets/760b31b9-f113-46cf-becf-a2f129ae907a)|

Resolve #243 