### PR TITLE
Adds GitHub templates to create a standard in future issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,76 @@
+name: Bug Report
+
+description: The form for submitting a bug.
+
+title: "[Bug]: "
+
+labels: ["bug"]
+
+# assignees:
+#   - dariowskii # You can assign a specific user to the issue
+  
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Thanks for taking the time to fill out this bug report!
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Flutter Version
+      description: What version of our Flutter are you running?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: What platform are you seeing the problem on?
+      multiple: true
+      options:
+        - iOS
+        - Android
+        - Web
+        - Windows
+        - MacOS
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: platform-version
+    attributes:
+      label: What is the platform's OS version?
+      placeholder: ex. iOS 16.0
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+      
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please copy and paste any screenshots, if you have!

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,33 @@
+name: Feature Request
+
+description: Submit your request here!
+
+title: "[Feature]: "
+
+labels: ["enhancement"]
+
+# assignees:
+#   - dariowskii # You can assign a specific user to the issue
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Let me know what you would like to add!
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Explain your idea 💡
+      description: Please provide some information about you want like to add and insert some *pseudo-syntax*
+      placeholder: I would really like to add...
+      
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3-information.yml
+++ b/.github/ISSUE_TEMPLATE/3-information.yml
@@ -1,0 +1,31 @@
+name: Information Request
+
+description: Do you need some information?
+
+title: "[INFO]: "
+
+labels: ["question"]
+
+# assignees:
+#   - dariowskii # You can assign a specific user to the issue
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Do you need some information?
+
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+      
+  - type: textarea
+    id: info
+    attributes:
+      label: What do you want to know?
+      description: Please be detailed in your request for information, including any use cases or pieces of code you would like help with
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This pull request introduces new issue templates for bug reports, feature requests, and information requests, along with a configuration change to disable blank issues.

New issue templates:

* [`.github/ISSUE_TEMPLATE/1-bug.yml`](diffhunk://#diff-6776d62e4a2433668f6f50806c424a3f35f7c39b885e14ce2dc35ca8510b861aR1-R76): Added a template for submitting bug reports, including fields for contact details, bug description, Flutter version, platform, platform version, logs, and screenshots.
* [`.github/ISSUE_TEMPLATE/2-feature-request.yml`](diffhunk://#diff-42d9c9c3c7ade4413771f73027bb9d90ddda0f8bf6a738d2e1ded1bd426d4b01R1-R33): Added a template for submitting feature requests, including fields for contact details and a detailed proposal.
* [`.github/ISSUE_TEMPLATE/3-information.yml`](diffhunk://#diff-236a78480919462a7fde2c2ad80500ce9e5deef40ef5d0218c7ebc134af60718R1-R31): Added a template for requesting information, including fields for contact details and a detailed description of the information needed.

Configuration change:

* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2R1): Disabled the ability to submit blank issues.