### PR TITLE
fix: 232 | Rework of 'is_first_login' variable

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,9 @@ void main() async {
 
   SharedPreferences preferences = await SharedPreferences.getInstance();
 
+  // Even though the saved key refers to a 'user first login',
+  // the behavior mimics a 'has user completed onboarding process' check.
+  // The key has not been renamed to maintain support for the app's previous versions.
   _isFirstLogin = preferences.getBool('is_first_login') ?? true;
 
   // perform recurring transactions checks

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,7 +29,7 @@ void main() async {
   final bool? isFirstLoginCachedValue = _sharedPreferences.getBool('is_first_login');
   final bool isOnBoardingCompletedKeyNotSaved = _sharedPreferences.getBool('onboarding_completed') == null;
   if (isFirstLoginCachedValue != null && isOnBoardingCompletedKeyNotSaved) {
-    await _sharedPreferences.setBool('onboarding_completed', isFirstLoginCachedValue);
+    await _sharedPreferences.setBool('onboarding_completed', !isFirstLoginCachedValue);
   }
 
   // perform recurring transactions checks
@@ -52,7 +52,7 @@ class Launcher extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
 
-    final bool isOnboardingCompleted = _sharedPreferences.getBool('onboarding_completed') ?? true;
+    final bool isOnboardingCompleted = _sharedPreferences.getBool('onboarding_completed') ?? false;
 
     final appThemeState = ref.watch(appThemeStateNotifier);
     return MaterialApp(
@@ -61,7 +61,7 @@ class Launcher extends ConsumerWidget {
       darkTheme: AppTheme.darkTheme,
       themeMode: appThemeState.isDarkModeEnabled ? ThemeMode.dark : ThemeMode.light,
       onGenerateRoute: makeRoute,
-      initialRoute: isOnboardingCompleted ? '/onboarding' : '/',
+      initialRoute: !isOnboardingCompleted ? '/onboarding' : '/',
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,6 +23,15 @@ void main() async {
 
   _sharedPreferences = await SharedPreferences.getInstance();
 
+  // KV migration from the 'is_first_login' key to 'onboarding_completed'
+  // to correctly handle the completion of the onboarding process
+  // (To consider to remove in later future)
+  final bool? isFirstLoginCachedValue = _sharedPreferences.getBool('is_first_login');
+  final bool isOnBoardingCompletedKeyNotSaved = _sharedPreferences.getBool('onboarding_completed') == null;
+  if (isFirstLoginCachedValue != null && isOnBoardingCompletedKeyNotSaved) {
+    await _sharedPreferences.setBool('onboarding_completed', isFirstLoginCachedValue);
+  }
+
   // perform recurring transactions checks
   DateTime? lastCheckGetPref = _sharedPreferences.getString('last_recurring_transactions_check') != null ? DateTime.parse(_sharedPreferences.getString('last_recurring_transactions_check')!) : null;
   DateTime? lastRecurringTransactionsCheck = lastCheckGetPref;
@@ -43,10 +52,7 @@ class Launcher extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
 
-    // Although the saved key refers to 'is_first_login',
-    // its behavior aligns with a 'has the user completed onboarding' check.
-    // It has not been renamed to maintain compatibility with previous versions.
-    final bool isFirstLogin = _sharedPreferences.getBool('is_first_login') ?? true;
+    final bool isOnboardingCompleted = _sharedPreferences.getBool('onboarding_completed') ?? true;
 
     final appThemeState = ref.watch(appThemeStateNotifier);
     return MaterialApp(
@@ -55,7 +61,7 @@ class Launcher extends ConsumerWidget {
       darkTheme: AppTheme.darkTheme,
       themeMode: appThemeState.isDarkModeEnabled ? ThemeMode.dark : ThemeMode.light,
       onGenerateRoute: makeRoute,
-      initialRoute: isFirstLogin ? '/onboarding' : '/',
+      initialRoute: isOnboardingCompleted ? '/onboarding' : '/',
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,7 @@ import 'routes.dart';
 import 'utils/app_theme.dart';
 import 'utils/notifications_service.dart';
 
-bool? _isFirstLogin = true;
+late bool _isFirstLogin;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -23,9 +23,7 @@ void main() async {
 
   SharedPreferences preferences = await SharedPreferences.getInstance();
 
-  bool? getPref = preferences.getBool('is_first_login');
-  getPref == null ? await preferences.setBool('is_first_login', false) : null;
-  _isFirstLogin = getPref;
+  _isFirstLogin = preferences.getBool('is_first_login') ?? true;
 
   // perform recurring transactions checks
   DateTime? lastCheckGetPref = preferences.getString('last_recurring_transactions_check') != null ? DateTime.parse(preferences.getString('last_recurring_transactions_check')!) : null;
@@ -53,7 +51,7 @@ class Launcher extends ConsumerWidget {
       darkTheme: AppTheme.darkTheme,
       themeMode: appThemeState.isDarkModeEnabled ? ThemeMode.dark : ThemeMode.light,
       onGenerateRoute: makeRoute,
-      initialRoute: _isFirstLogin == null || _isFirstLogin! ? '/onboarding' : '/',
+      initialRoute: _isFirstLogin ? '/onboarding' : '/',
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,9 +23,9 @@ void main() async {
 
   SharedPreferences preferences = await SharedPreferences.getInstance();
 
-  // Even though the saved key refers to a 'user first login',
-  // the behavior mimics a 'has user completed onboarding process' check.
-  // The key has not been renamed to maintain support for the app's previous versions.
+  // Although the saved key refers to 'is_first_login',
+  // its behavior aligns with a 'has the user completed onboarding' check.
+  // It has not been renamed to maintain compatibility with previous versions.
   _isFirstLogin = preferences.getBool('is_first_login') ?? true;
 
   // perform recurring transactions checks

--- a/lib/pages/onboarding_page/widgets/account_setup.dart
+++ b/lib/pages/onboarding_page/widgets/account_setup.dart
@@ -31,7 +31,7 @@ class _AccountSetupState extends ConsumerState<AccountSetup> {
 
   Future<void> _flagOnBoardingCompleted() async {
     final SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
-    sharedPreferences.setBool('onboarding_completed', false);
+    sharedPreferences.setBool('onboarding_completed', true);
   }
 
   @override

--- a/lib/pages/onboarding_page/widgets/account_setup.dart
+++ b/lib/pages/onboarding_page/widgets/account_setup.dart
@@ -31,7 +31,7 @@ class _AccountSetupState extends ConsumerState<AccountSetup> {
 
   Future<void> _flagOnBoardingCompleted() async {
     final SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
-    sharedPreferences.setBool('is_first_login', false);
+    sharedPreferences.setBool('onboarding_completed', false);
   }
 
   @override

--- a/lib/pages/onboarding_page/widgets/account_setup.dart
+++ b/lib/pages/onboarding_page/widgets/account_setup.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../constants/constants.dart';
 import '../../../providers/accounts_provider.dart';
@@ -26,6 +27,11 @@ class _AccountSetupState extends ConsumerState<AccountSetup> {
     setState(() {
       _validAmount = RegExp(r'^\d*\.?\d{0,2}$').hasMatch(value);
     });
+  }
+
+  Future<void> _flagOnBoardingCompleted() async {
+    final SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
+    sharedPreferences.setBool('is_first_login', false);
   }
 
   @override
@@ -306,6 +312,7 @@ class _AccountSetupState extends ConsumerState<AccountSetup> {
                   const SizedBox(height: 10),
                   ElevatedButton(
                     onPressed: () {
+                      _flagOnBoardingCompleted();
                       Navigator.of(context)
                           .pushNamedAndRemoveUntil('/', (route) => false);
                     },
@@ -361,6 +368,7 @@ class _AccountSetupState extends ConsumerState<AccountSetup> {
                                   startingValue:
                                       num.tryParse(amountController.text) ?? 0,
                                 );
+                            _flagOnBoardingCompleted();
                             Navigator.of(context)
                                 .pushNamedAndRemoveUntil('/', (route) => false);
                           }


### PR DESCRIPTION
### What does this PR do?  
This PR resolves issue #232, where users who performed an import process were required to redo the onboarding process. Additionally, I noticed that the handling of the `is_first_login` variable in the main function might be not ideal.  

### Why was this bug occurring?  
The issue came from Phoenix, the library used to restart/reload the app after completing an import process. Phoenix re-executes the `build()` method of the `Launcher` widget, preventing the `_isFirstLogin` variable in `main.dart` from being properly reassigned. Its value was only retrieved inside the `main()` function, leading to incorrect behavior.  

### More bugs than expected  
While investigating, I also found another bug: when a user opens the app for the first time, the onboarding process is displayed. However, if they close the app while still in the onboarding flow, they will never see the onboarding process again. This happens because, in the current implementation, the `is_first_login` flag is set to `true` when the app executes the `main()` function (The first start does not get affected). This PR also addresses this issue by ensuring the flag is set to `true` only after the user completes onboarding.  

### Code changes  
To properly track whether the user has completed onboarding, the `is_first_login` value is now checked inside the `build()` method of the `Launcher` widget. Instead of storing its value in the `_isFirstLogin` variable (which was only retrieved in `main()`), the app now directly reads the updated value from `SharedPreferences` whenever `Launcher` is rebuilt.  

This ensures that whenever the app restarts, *whether due to Phoenix or any other reasons*, it always retrieves the latest `is_first_login` value, preventing incorrect onboarding behavior. The key name remains unchanged to avoid forcing existing users to redo the onboarding.  

### (!) Edit
A KV migration has been implemented, making users migrate from the `is_first_login` key to `onboarding_completed` key, without problems.


https://github.com/user-attachments/assets/791cd601-2052-450e-b754-8991fd3dbd08


https://github.com/user-attachments/assets/7fb4c3b9-f941-4f08-93e4-f6feb8e330eb

