### PR TITLE
Ability to delete Categories and consequences on transactions and recurring transactions

### DIFF
--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -20,6 +20,7 @@ const Map<String, IconData> iconList = {
   'device_thermostat': Icons.device_thermostat,
   'dry_cleaning': Icons.dry_cleaning,
   'work': Icons.work,
+  'question_mark': Icons.question_mark,
 };
 
 const Map<String, IconData> accountIconList = {
@@ -31,6 +32,7 @@ const Map<String, IconData> accountIconList = {
 
 // colors
 const categoryColorList = [
+  category0,
   category1,
   category2,
   category3,
@@ -43,6 +45,7 @@ const categoryColorList = [
 ];
 
 const darkCategoryColorList = [
+  darkCategory0,
   darkCategory1,
   darkCategory2,
   darkCategory3,

--- a/lib/constants/style.dart
+++ b/lib/constants/style.dart
@@ -35,6 +35,7 @@ const grey1 = Color(0xFF666666);
 const grey2 = Color(0xFFB9BABC);
 const grey3 = Color(0xFFF4F4F4);
 
+const category0 = Color(0xFFB9BABC);
 const category1 = Color(0xFFEDC31C);
 const category2 = Color(0xFFF68428);
 const category3 = Color(0xFFFF4754);
@@ -71,6 +72,7 @@ const darkGrey2 = Color(0xFFC6C7C8);
 const darkGrey3 = Color(0xFF181E25);
 const darkGrey4 = Color(0xFF2E3338);
 
+const darkCategory0 = Color(0xFFB9BABC);
 const darkCategory1 = Color(0xFFE3B912);
 const darkCategory2 = Color(0xFFF6740C);
 const darkCategory3 = Color(0xFFFA3240);

--- a/lib/database/sossoldi_database.dart
+++ b/lib/database/sossoldi_database.dart
@@ -106,9 +106,17 @@ class SossoldiDatabase {
         `${CategoryTransactionFields.color}` $integerNotNull,
         `${CategoryTransactionFields.note}` $text,
         `${CategoryTransactionFields.parent}` $integer,
+        `${CategoryTransactionFields.markedAsDeleted}` $integerNotNull CHECK (${CategoryTransactionFields.markedAsDeleted} IN (0, 1)),
         `${CategoryTransactionFields.createdAt}` $textNotNull,
         `${CategoryTransactionFields.updatedAt}` $textNotNull
       )
+    ''');
+
+    // Default "Uncategorized" Category
+    await database.execute('''
+      INSERT INTO `$categoryTransactionTable`(`${CategoryTransactionFields.id}`, `${CategoryTransactionFields.name}`, `${CategoryTransactionFields.type}`, `${CategoryTransactionFields.symbol}`, `${CategoryTransactionFields.color}`, `${CategoryTransactionFields.note}`, `${CategoryTransactionFields.parent}`, `${CategoryTransactionFields.markedAsDeleted}`, `${CategoryTransactionFields.createdAt}`, `${CategoryTransactionFields.updatedAt}`) VALUES
+        (0, "Uncategorized", "IN", "question_mark", 0, 'This is a default category for no categorized transactions', null, '0', '${DateTime.now()}', '${DateTime.now()}'),
+        (1, "Uncategorized", "OUT", "question_mark", 0, 'This is a default category for no categorized transactions', null, '0', '${DateTime.now()}', '${DateTime.now()}');
     ''');
 
     // Budget Table
@@ -142,7 +150,6 @@ class SossoldiDatabase {
         ("CHF", "CHF", "Switzerland Franc", 0),
         ("£", "GBP", "United Kingdom Pound", 0);
     ''');
-
   }
 
   Future<String> exportToCSV() async {
@@ -180,7 +187,8 @@ class SossoldiDatabase {
         final List<Map<String, dynamic>> rows = await db.query(tableName);
 
         for (var row in rows) {
-          List<dynamic> csvRow = List.filled(headers.length, ''); // Initialize with empty strings
+          List<dynamic> csvRow =
+              List.filled(headers.length, ''); // Initialize with empty strings
           csvRow[0] = tableName; // Set table name
 
           // Fill in values for existing columns
@@ -215,7 +223,8 @@ class SossoldiDatabase {
       }
 
       final String csvData = await file.readAsString();
-      final List<List<dynamic>> rows = const CsvToListConverter().convert(csvData);
+      final List<List<dynamic>> rows =
+          const CsvToListConverter().convert(csvData);
 
       if (rows.isEmpty) {
         throw Exception('CSV file is empty');
@@ -251,7 +260,8 @@ class SossoldiDatabase {
             for (int i = 1; i < tableRows.length; i++) {
               final Map<String, dynamic> row = {};
               for (int j = 0; j < headers.length; j++) {
-                if (j != tableNameIndex) { // Skip the table_name column
+                if (j != tableNameIndex) {
+                  // Skip the table_name column
                   final String header = headers[j];
                   final dynamic value = tableRows[i][j];
 
@@ -289,14 +299,16 @@ class SossoldiDatabase {
 
     // Add fake categories
     await _database?.execute('''
-      INSERT INTO categoryTransaction(id, name, type, symbol, color, note, parent, createdAt, updatedAt) VALUES
-        (10, "Out", "OUT", "restaurant", 0, '', null, '${DateTime.now()}', '${DateTime.now()}'),
-        (11, "Home", "OUT", "home", 1, '', null, '${DateTime.now()}', '${DateTime.now()}'),
-        (12, "Furniture","OUT", "home", 2, '', 11, '${DateTime.now()}', '${DateTime.now()}'),
-        (13, "Shopping", "OUT", "shopping_cart", 3, '', null, '${DateTime.now()}', '${DateTime.now()}'),
-        (14, "Leisure", "OUT", "subscriptions", 4, '', null, '${DateTime.now()}', '${DateTime.now()}'),
-        (15, "Transports", "OUT", "directions_car_rounded", 6, '', null, '${DateTime.now()}', '${DateTime.now()}'),
-        (16, "Salary", "IN", "work", 5, '', null, '${DateTime.now()}', '${DateTime.now()}');
+      INSERT INTO categoryTransaction(id, name, type, symbol, color, note, parent, markedAsDeleted, createdAt, updatedAt) VALUES
+        (0, "Uncategorized", "IN", "question_mark", 0, 'This is a default category for no categorized transactions', null, 0, '${DateTime.now()}', '${DateTime.now()}'),
+        (1, "Uncategorized", "OUT", "question_mark", 0, 'This is a default category for no categorized transactions', null, 0, '${DateTime.now()}', '${DateTime.now()}'),
+        (10, "Out", "OUT", "restaurant", 1, '', null, 0, '${DateTime.now()}', '${DateTime.now()}'),
+        (11, "Home", "OUT", "home", 2, '', null, 0, '${DateTime.now()}', '${DateTime.now()}'),
+        (12, "Furniture","OUT", "home", 3, '', 11, 0, '${DateTime.now()}', '${DateTime.now()}'),
+        (13, "Shopping", "OUT", "shopping_cart", 4, '', null, 0, '${DateTime.now()}', '${DateTime.now()}'),
+        (14, "Leisure", "OUT", "subscriptions", 5, '', null, 0, '${DateTime.now()}', '${DateTime.now()}'),
+        (15, "Transports", "OUT", "directions_car_rounded", 6, '', null, 0, '${DateTime.now()}', '${DateTime.now()}'),
+        (16, "Salary", "IN", "work", 5, '', null, 0, '${DateTime.now()}', '${DateTime.now()}');
     ''');
 
     // Add currencies

--- a/lib/model/category_transaction.dart
+++ b/lib/model/category_transaction.dart
@@ -58,7 +58,7 @@ const userCategoriesFilter = CategoryFilter(
   showDeletedCategories: false,
 );
 
-const onlyActiveCategoriesFilter = CategoryFilter(
+const availableCategoriesFilter = CategoryFilter(
   showSystemCategories: true,
   showDeletedCategories: false,
 );

--- a/lib/pages/add_page/widgets/category_selector.dart
+++ b/lib/pages/add_page/widgets/category_selector.dart
@@ -66,45 +66,54 @@ class _CategorySelectorState extends ConsumerState<CategorySelector>
                     height: 74,
                     width: double.infinity,
                     child: categoriesList.when(
-                      data: (categories) => ListView.builder(
-                        itemCount: categories.length, // to prevent range error
-                        scrollDirection: Axis.horizontal,
-                        shrinkWrap: true,
-                        itemBuilder: (context, i) {
-                          CategoryTransaction category = categories[i];
-                          return GestureDetector(
-                            onTap: () => {
-                              ref.read(categoryProvider.notifier).state =
-                                  category,
-                              Navigator.of(context).pop(),
-                            },
-                            child: Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 16.0),
-                              child: Column(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: [
-                                  RoundedIcon(
-                                    icon: iconList[category.symbol],
-                                    backgroundColor:
-                                        categoryColorListTheme[category.color],
-                                  ),
-                                  Text(
-                                    category.name,
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .labelLarge!
-                                        .copyWith(
-                                            color: Theme.of(context)
-                                                .colorScheme
-                                                .primary),
-                                  ),
-                                ],
+                      data: (categories) {
+                        //availableCategories without markedAsDeleted
+                        final availableCategories = categories
+                            .where(
+                                (category) => category.markedAsDeleted == false)
+                            .toList();
+
+                        return ListView.builder(
+                          itemCount: availableCategories.length,
+                          scrollDirection: Axis.horizontal,
+                          shrinkWrap: true,
+                          itemBuilder: (context, i) {
+                            CategoryTransaction category =
+                                availableCategories[i];
+                            return GestureDetector(
+                              onTap: () => {
+                                ref.read(categoryProvider.notifier).state =
+                                    category,
+                                Navigator.of(context).pop(),
+                              },
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 16.0),
+                                child: Column(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    RoundedIcon(
+                                      icon: iconList[category.symbol],
+                                      backgroundColor: categoryColorListTheme[
+                                          category.color],
+                                    ),
+                                    Text(
+                                      category.name,
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .labelLarge!
+                                          .copyWith(
+                                              color: Theme.of(context)
+                                                  .colorScheme
+                                                  .primary),
+                                    ),
+                                  ],
+                                ),
                               ),
-                            ),
-                          );
-                        },
-                      ),
+                            );
+                          },
+                        );
+                      },
                       loading: () =>
                           const Center(child: CircularProgressIndicator()),
                       error: (err, stack) => Text('Error: $err'),
@@ -142,10 +151,10 @@ class _CategorySelectorState extends ConsumerState<CategorySelector>
                                   categoryColorListTheme[category.color],
                             ),
                             title: Text(category.name),
-                            trailing: ref.watch(categoryProvider)?.id ==
-                                    category.id
-                                ? Icon(Icons.check)
-                                : null,
+                            trailing:
+                                ref.watch(categoryProvider)?.id == category.id
+                                    ? Icon(Icons.check)
+                                    : null,
                           );
                         },
                       ),

--- a/lib/pages/categories/add_category.dart
+++ b/lib/pages/categories/add_category.dart
@@ -5,6 +5,7 @@ import '../../constants/functions.dart';
 import '../../constants/style.dart';
 import '../../model/category_transaction.dart';
 import '../../providers/categories_provider.dart';
+import 'widgets/delete_category_dialog.dart';
 
 class AddCategory extends ConsumerStatefulWidget {
   final bool hideIncome;
@@ -374,14 +375,8 @@ class _AddCategoryState extends ConsumerState<AddCategory> with Functions {
                       width: double.infinity,
                       padding: const EdgeInsets.all(16),
                       child: TextButton.icon(
-                        onPressed: () => ref
-                            .read(categoriesProvider.notifier)
-                            .removeCategory(selectedCategory.id!)
-                            .whenComplete(() {
-                          if (context.mounted) {
-                            Navigator.of(context).pop();
-                          }
-                        }),
+                        onPressed: () => showDeleteCategoryDialog(
+                            context, ref, selectedCategory),
                         style: TextButton.styleFrom(
                           side: const BorderSide(color: red, width: 1),
                         ),
@@ -427,7 +422,8 @@ class _AddCategoryState extends ConsumerState<AddCategory> with Functions {
                   if (nameController.text.isNotEmpty) {
                     if (selectedCategory != null) {
                       await ref
-                          .read(categoriesProvider.notifier)
+                          .read(
+                              categoriesProvider(userCategoriesFilter).notifier)
                           .updateCategory(
                             name: nameController.text,
                             type: categoryType,
@@ -435,7 +431,10 @@ class _AddCategoryState extends ConsumerState<AddCategory> with Functions {
                             color: categoryColor,
                           );
                     } else {
-                      await ref.read(categoriesProvider.notifier).addCategory(
+                      await ref
+                          .read(
+                              categoriesProvider(userCategoriesFilter).notifier)
+                          .addCategory(
                             name: nameController.text,
                             type: categoryType,
                             icon: categoryIcon,

--- a/lib/pages/categories/category_list.dart
+++ b/lib/pages/categories/category_list.dart
@@ -18,7 +18,7 @@ class CategoryList extends ConsumerStatefulWidget {
 class _CategoryListState extends ConsumerState<CategoryList> with Functions {
   @override
   Widget build(BuildContext context) {
-    final categorysList = ref.watch(categoriesProvider);
+    final categorysList = ref.watch(categoriesProvider(userCategoriesFilter));
     ref.listen(selectedCategoryProvider, (_, __) {});
     return Scaffold(
       appBar: AppBar(

--- a/lib/pages/categories/widgets/delete_category_dialog.dart
+++ b/lib/pages/categories/widgets/delete_category_dialog.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../model/category_transaction.dart';
+import '../../../providers/categories_provider.dart';
+
+Future<void> showDeleteCategoryDialog(
+    BuildContext context, WidgetRef ref, selectedCategory) async {
+  return showDialog<void>(
+    context: context,
+    builder: (BuildContext context) {
+      return AlertDialog(
+        content: const SingleChildScrollView(
+          child: ListBody(
+            children: <Widget>[
+              Text(
+                  'With “Mark as deleted,” transitions with the category will be available, but new ones cannot be created\n'),
+              Text(
+                  'With “Delete” all transitions with that category will automatically be “Uncategorized”'),
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          TextButton(
+            child: Text(
+              "Mark as deleted",
+              style: TextStyle(color: Theme.of(context).colorScheme.primary),
+            ),
+            onPressed: () => ref
+                .read(categoriesProvider(userCategoriesFilter).notifier)
+                .markAsDeleted(selectedCategory.id)
+                .whenComplete(() {
+              if (context.mounted) {
+                Navigator.of(context).pop();
+              }
+            }),
+          ),
+          TextButton(
+            child: Text(
+              "Delete",
+              style: TextStyle(color: Theme.of(context).colorScheme.primary),
+            ),
+            onPressed: () => ref
+                .read(categoriesProvider(userCategoriesFilter).notifier)
+                .removeCategory(selectedCategory.id!)
+                .whenComplete(() {
+              if (context.mounted) {
+                Navigator.of(context).pop();
+              }
+            }),
+          ),
+        ],
+      );
+    },
+  );
+}

--- a/lib/pages/categories/widgets/delete_category_dialog.dart
+++ b/lib/pages/categories/widgets/delete_category_dialog.dart
@@ -5,6 +5,13 @@ import '../../../providers/categories_provider.dart';
 
 Future<void> showDeleteCategoryDialog(
     BuildContext context, WidgetRef ref, selectedCategory) async {
+  void backToCategoryList() {
+    if (context.mounted) {
+      Navigator.of(context)
+          .popUntil((route) => route.settings.name == '/category-list');
+    }
+  }
+
   return showDialog<void>(
     context: context,
     builder: (BuildContext context) {
@@ -13,9 +20,11 @@ Future<void> showDeleteCategoryDialog(
           child: ListBody(
             children: <Widget>[
               Text(
-                  'With “Mark as deleted,” transitions with the category will be available, but new ones cannot be created\n'),
+                'With "Mark as deleted," transitions with the category will be available, but new ones cannot be created\n',
+              ),
               Text(
-                  'With “Delete” all transitions with that category will automatically be “Uncategorized”'),
+                'With "Delete" all transitions with that category will automatically be "Uncategorized"',
+              ),
             ],
           ),
         ),
@@ -28,11 +37,7 @@ Future<void> showDeleteCategoryDialog(
             onPressed: () => ref
                 .read(categoriesProvider(userCategoriesFilter).notifier)
                 .markAsDeleted(selectedCategory.id)
-                .whenComplete(() {
-              if (context.mounted) {
-                Navigator.of(context).pop();
-              }
-            }),
+                .whenComplete(backToCategoryList),
           ),
           TextButton(
             child: Text(
@@ -42,11 +47,7 @@ Future<void> showDeleteCategoryDialog(
             onPressed: () => ref
                 .read(categoriesProvider(userCategoriesFilter).notifier)
                 .removeCategory(selectedCategory.id!)
-                .whenComplete(() {
-              if (context.mounted) {
-                Navigator.of(context).pop();
-              }
-            }),
+                .whenComplete(backToCategoryList),
           ),
         ],
       );

--- a/lib/pages/onboarding_page/widgets/budget_setup.dart
+++ b/lib/pages/onboarding_page/widgets/budget_setup.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../model/category_transaction.dart';
 import '../../categories/add_category.dart';
 import '/constants/constants.dart';
 import '/constants/style.dart';
@@ -32,7 +33,7 @@ class _BudgetSetupState extends ConsumerState<BudgetSetup> {
     totalBudget = budgetsList?.fold<num>(
             0, (total, budget) => total + budget.amountLimit) ??
         0;
-    final categoriesGrid = ref.watch(categoriesProvider);
+    final categoriesGrid = ref.watch(categoriesProvider(userCategoriesFilter));
     return Scaffold(
       backgroundColor: blue7,
       body: SafeArea(

--- a/lib/pages/planning_page/manage_budget_page.dart
+++ b/lib/pages/planning_page/manage_budget_page.dart
@@ -21,8 +21,11 @@ class _ManageBudgetPageState extends ConsumerState<ManageBudgetPage> {
   List<Budget> deletedBudgets = [];
 
   void _loadCategories() async {
-    categories = await ref.read(categoriesProvider.notifier).getCategories();
-    categories.removeWhere((element) => element.type == CategoryTransactionType.income);
+    categories = await ref
+        .read(categoriesProvider(userCategoriesFilter).notifier)
+        .getCategories();
+    categories.removeWhere(
+        (element) => element.type == CategoryTransactionType.income);
     budgets = await ref.read(budgetsProvider.notifier).getBudgets();
     setState(() {});
   }
@@ -101,16 +104,19 @@ class _ManageBudgetPageState extends ConsumerState<ManageBudgetPage> {
                     child: BudgetCategorySelector(
                       categories: categories,
                       categoriesAlreadyUsed: categories
-                          .where((element) => budgets.map((e) => e.name).contains(element.name))
+                          .where((element) =>
+                              budgets.map((e) => e.name).contains(element.name))
                           .map((e) => e.name)
                           .toList(),
                       budget: budgets[index],
                       initSelectedCategory: categories
-                              .where((element) => element.id == budgets[index].idCategory)
+                              .where((element) =>
+                                  element.id == budgets[index].idCategory)
                               .isEmpty
                           ? categories[0]
                           : categories
-                              .where((element) => element.id == budgets[index].idCategory)
+                              .where((element) =>
+                                  element.id == budgets[index].idCategory)
                               .first,
                       onBudgetChanged: (updatedBudget) {
                         updateBudget(updatedBudget, index);
@@ -120,7 +126,8 @@ class _ManageBudgetPageState extends ConsumerState<ManageBudgetPage> {
                 },
               ),
               SizedBox(height: 8),
-              Text("Swipe left to delete", style: Theme.of(context).textTheme.bodySmall),
+              Text("Swipe left to delete",
+                  style: Theme.of(context).textTheme.bodySmall),
               SizedBox(height: 12),
               TextButton.icon(
                 icon: Icon(Icons.add_circle, size: 32),

--- a/lib/pages/planning_page/widget/budget_card.dart
+++ b/lib/pages/planning_page/widget/budget_card.dart
@@ -5,6 +5,7 @@ import '../../../custom_widgets/default_container.dart';
 import '../../../model/budget.dart';
 import '../../../model/transaction.dart';
 import '../../../providers/budgets_provider.dart';
+import '../../../providers/categories_provider.dart';
 import '../../../providers/currency_provider.dart';
 import '../../../providers/transactions_provider.dart';
 import '../../graphs_page/widgets/linear_progress_bar.dart';
@@ -23,7 +24,8 @@ class _BudgetCardState extends ConsumerState<BudgetCard> {
   @override
   Widget build(BuildContext context) {
     final budgets = ref.watch(budgetsProvider.notifier).getBudgets();
-    final transactions = ref.watch(transactionsProvider.notifier).getMonthlyTransactions();
+    final transactions =
+        ref.watch(transactionsProvider.notifier).getMonthlyTransactions();
     final currencyState = ref.watch(currencyStateNotifier);
 
     return DefaultContainer(
@@ -44,47 +46,57 @@ class _BudgetCardState extends ConsumerState<BudgetCard> {
                 ? Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      Text("Composition", style: Theme.of(context).textTheme.titleLarge),
+                      Text("Composition",
+                          style: Theme.of(context).textTheme.titleLarge),
                       BudgetPieChart(budgets: budgets as List<Budget>),
-                      Text("Progress", style: Theme.of(context).textTheme.titleLarge),
+                      Text("Progress",
+                          style: Theme.of(context).textTheme.titleLarge),
                       const SizedBox(height: 10),
                       ListView.separated(
                         shrinkWrap: true,
                         physics: const NeverScrollableScrollPhysics(),
                         itemCount: budgets.length,
                         itemBuilder: (BuildContext context, int index) {
-                          num spent = num.parse((transactions as List<Transaction>)
-                              .where((t) => t.idCategory == budgets[index].idCategory)
-                              .fold(0.0, (sum, t) => sum + t.amount)
-                              .toStringAsFixed(2));
+                          num spent = num.parse(
+                              (transactions as List<Transaction>)
+                                  .where((t) =>
+                                      t.idCategory == budgets[index].idCategory)
+                                  .fold(0.0, (sum, t) => sum + t.amount)
+                                  .toStringAsFixed(2));
                           Budget budget = budgets.elementAt(index);
+                          final budgetCategory = ref
+                              .watch(categoryByIdProvider(budget.idCategory))
+                              .value;
                           return Column(
                             children: [
                               Row(
                                 children: [
                                   Text(
                                     budget.name!,
-                                    style: const TextStyle(fontWeight: FontWeight.normal),
+                                    style: const TextStyle(
+                                        fontWeight: FontWeight.normal),
                                   ),
                                   const Spacer(),
                                   spent >= (budget.amountLimit * 0.9)
-                                      ? const Icon(Icons.error_outline, color: Colors.red)
+                                      ? const Icon(Icons.error_outline,
+                                          color: Colors.red)
                                       : Container(),
                                   Text(
                                     "$spent${currencyState.selectedCurrency.symbol}/${budget.amountLimit}${currencyState.selectedCurrency.symbol}",
-                                    style: const TextStyle(fontWeight: FontWeight.normal),
+                                    style: const TextStyle(
+                                        fontWeight: FontWeight.normal),
                                   ),
                                 ],
                               ),
                               const SizedBox(height: 4),
                               LinearProgressBar(
-                                type: BarType.category,
-                                colorIndex: index,
-                                amount: (spent == 0 || budget.amountLimit == 0)
-                                      ? 0
-                                      : spent,
-                                total: budget.amountLimit
-                              ),
+                                  type: BarType.category,
+                                  colorIndex: budgetCategory?.color ?? 1,
+                                  amount:
+                                      (spent == 0 || budget.amountLimit == 0)
+                                          ? 0
+                                          : spent,
+                                  total: budget.amountLimit),
                             ],
                           );
                         },
@@ -131,17 +143,16 @@ class _BudgetCardState extends ConsumerState<BudgetCard> {
                             builder: (BuildContext context) {
                               return FractionallySizedBox(
                                   heightFactor: 0.9,
-                                  child:
-                                      ManageBudgetPage(onRefreshBudgets: widget.onRefreshBudgets));
+                                  child: ManageBudgetPage(
+                                      onRefreshBudgets:
+                                          widget.onRefreshBudgets));
                             },
                           );
                         },
                         label: Text(
                           "Create budget",
-                          style: Theme.of(context)
-                              .textTheme
-                              .titleSmall!
-                              .apply(color: Theme.of(context).colorScheme.secondary),
+                          style: Theme.of(context).textTheme.titleSmall!.apply(
+                              color: Theme.of(context).colorScheme.secondary),
                         ),
                         style: TextButton.styleFrom(
                           backgroundColor: Colors.white,

--- a/lib/pages/planning_page/widget/budget_pie_chart.dart
+++ b/lib/pages/planning_page/widget/budget_pie_chart.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../constants/constants.dart';
 import '../../../model/budget.dart';
+import '../../../providers/categories_provider.dart';
 import '../../../providers/currency_provider.dart';
 
 class BudgetPieChart extends ConsumerStatefulWidget {
@@ -50,11 +51,12 @@ class BudgetPieChartState extends ConsumerState<BudgetPieChart> {
   List<PieChartSectionData> showingSections() {
     return List.generate(widget.budgets.length, (i) {
       final Budget budget = widget.budgets.elementAt(i);
-
+      final budgetCategory =
+          ref.watch(categoryByIdProvider(budget.idCategory)).value;
       double value = (budget.amountLimit / totalBudget) * 100;
 
       return PieChartSectionData(
-        color: categoryColorList[i],
+        color: categoryColorList[budgetCategory?.color ?? 1],
         value: value,
         title: "",
         radius: 20,

--- a/lib/pages/planning_page/widget/recurring_payment_card.dart
+++ b/lib/pages/planning_page/widget/recurring_payment_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../constants/constants.dart';
 import '../../../custom_widgets/rounded_icon.dart';
+import '../../../model/category_transaction.dart';
 import '../../../model/recurring_transaction.dart';
 import '../../../providers/theme_provider.dart';
 import 'older_recurring_payments.dart';
@@ -35,7 +36,8 @@ class RecurringPaymentCard extends ConsumerWidget with Functions {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final categories = ref.watch(categoriesProvider).value;
+    final categories =
+        ref.watch(categoriesProvider(userCategoriesFilter)).value;
     final accounts = ref.watch(accountsProvider).value;
     final isDarkMode = ref.watch(appThemeStateNotifier).isDarkModeEnabled;
     final currencyState = ref.watch(currencyStateNotifier);
@@ -51,8 +53,7 @@ class RecurringPaymentCard extends ConsumerWidget with Functions {
               boxShadow: [defaultShadow],
             ),
             child: Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 12),
               decoration: BoxDecoration(
                 color: categoryColorList[cat.color].withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(8),

--- a/lib/pages/planning_page/widget/recurring_payment_card.dart
+++ b/lib/pages/planning_page/widget/recurring_payment_card.dart
@@ -36,8 +36,7 @@ class RecurringPaymentCard extends ConsumerWidget with Functions {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final categories =
-        ref.watch(categoriesProvider(userCategoriesFilter)).value;
+    final categories = ref.watch(categoriesProvider(allCategoriesFilter)).value;
     final accounts = ref.watch(accountsProvider).value;
     final isDarkMode = ref.watch(appThemeStateNotifier).isDarkModeEnabled;
     final currencyState = ref.watch(currencyStateNotifier);

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -10,6 +10,7 @@ import '../constants/style.dart';
 import '../custom_widgets/alert_dialog.dart';
 import '../custom_widgets/default_card.dart';
 import '../database/sossoldi_database.dart';
+import '../model/category_transaction.dart';
 import '../providers/accounts_provider.dart';
 import '../providers/budgets_provider.dart';
 import '../providers/categories_provider.dart';
@@ -100,7 +101,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                 onPressed: () => Navigator.pop(context),
                 child: Text(
                   "OK",
-                  style: TextStyle(color: Theme.of(context).colorScheme.primary),
+                  style:
+                      TextStyle(color: Theme.of(context).colorScheme.primary),
                 ),
               ),
             ],
@@ -129,7 +131,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         child: Column(
           children: [
             Padding(
-              padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 16.0),
+              padding:
+                  const EdgeInsets.symmetric(vertical: 24.0, horizontal: 16.0),
               child: GestureDetector(
                 onTap: _onSettingsTap,
                 child: Row(
@@ -152,7 +155,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                       style: Theme.of(context)
                           .textTheme
                           .headlineLarge!
-                          .copyWith(color: Theme.of(context).colorScheme.primary),
+                          .copyWith(
+                              color: Theme.of(context).colorScheme.primary),
                     ),
                   ],
                 ),
@@ -204,14 +208,20 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                                   style: Theme.of(context)
                                       .textTheme
                                       .titleLarge!
-                                      .copyWith(color: Theme.of(context).colorScheme.primary),
+                                      .copyWith(
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .primary),
                                 ),
                                 Text(
                                   setting[2].toString(),
                                   style: Theme.of(context)
                                       .textTheme
                                       .bodySmall!
-                                      .copyWith(color: Theme.of(context).colorScheme.primary),
+                                      .copyWith(
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .primary),
                                   overflow: TextOverflow.ellipsis,
                                   maxLines: 2,
                                 ),
@@ -252,7 +262,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                     onPressed: () async {
                       await SossoldiDatabase.instance.resetDatabase().then((v) {
                         ref.refresh(accountsProvider);
-                        ref.refresh(categoriesProvider);
+                        ref.refresh(categoriesProvider(userCategoriesFilter));
                         ref.refresh(transactionsProvider);
                         ref.refresh(budgetsProvider);
                         showSuccessDialog(context, "DB Cleared");
@@ -263,15 +273,18 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
                     child: const Text('CLEAR AND FILL DEMO DATA'),
                     onPressed: () async {
                       await SossoldiDatabase.instance.clearDatabase();
-                      await SossoldiDatabase.instance.fillDemoData().then((value) {
+                      await SossoldiDatabase.instance
+                          .fillDemoData()
+                          .then((value) {
                         ref.refresh(accountsProvider);
-                        ref.refresh(categoriesProvider);
+                        ref.refresh(categoriesProvider(userCategoriesFilter));
                         ref.refresh(transactionsProvider);
                         ref.refresh(budgetsProvider);
                         ref.refresh(dashboardProvider);
                         ref.refresh(lastTransactionsProvider);
                         ref.refresh(statisticsProvider);
-                        showSuccessDialog(context, "DB Cleared, and DEMO data added");
+                        showSuccessDialog(
+                            context, "DB Cleared, and DEMO data added");
                       });
                     },
                   ),

--- a/lib/pages/transactions_page/widgets/categories_tab.dart
+++ b/lib/pages/transactions_page/widgets/categories_tab.dart
@@ -23,13 +23,14 @@ class CategoriesTab extends ConsumerStatefulWidget {
 class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
   @override
   Widget build(BuildContext context) {
-    final categories = ref.watch(categoriesProvider);
+    final categories = ref.watch(categoriesProvider(userCategoriesFilter));
     final transactions = ref.watch(transactionsProvider);
     final transactionType = ref.watch(selectedTransactionTypeProvider);
 
     // create a map to link each categories with a list of its transactions
     // stored as Transaction to be passed to CategoryListTile
-    Map<int, List<Transaction>> categoryToTransactionsIncome = {}, categoryToTransactionsExpense = {};
+    Map<int, List<Transaction>> categoryToTransactionsIncome = {},
+        categoryToTransactionsExpense = {};
     Map<int, double> categoryToAmountIncome = {}, categoryToAmountExpense = {};
     double totalIncome = 0, totalExpense = 0;
 
@@ -40,29 +41,37 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
           if (categoryToTransactionsIncome.containsKey(categoryId)) {
             categoryToTransactionsIncome[categoryId]?.add(transaction);
           } else {
-            categoryToTransactionsIncome.putIfAbsent(categoryId, () => [transaction]);
+            categoryToTransactionsIncome.putIfAbsent(
+                categoryId, () => [transaction]);
           }
 
           // update total amount for the category
           totalIncome += transaction.amount;
           if (categoryToAmountIncome.containsKey(categoryId)) {
-            categoryToAmountIncome[categoryId] = categoryToAmountIncome[categoryId]! + transaction.amount.toDouble();
+            categoryToAmountIncome[categoryId] =
+                categoryToAmountIncome[categoryId]! +
+                    transaction.amount.toDouble();
           } else {
-            categoryToAmountIncome.putIfAbsent(categoryId, () => transaction.amount.toDouble());
+            categoryToAmountIncome.putIfAbsent(
+                categoryId, () => transaction.amount.toDouble());
           }
         } else if (transaction.type == TransactionType.expense) {
           if (categoryToTransactionsExpense.containsKey(categoryId)) {
             categoryToTransactionsExpense[categoryId]?.add(transaction);
           } else {
-            categoryToTransactionsExpense.putIfAbsent(categoryId, () => [transaction]);
+            categoryToTransactionsExpense.putIfAbsent(
+                categoryId, () => [transaction]);
           }
 
           // update total amount for the category
           totalExpense -= transaction.amount;
           if (categoryToAmountExpense.containsKey(categoryId)) {
-            categoryToAmountExpense[categoryId] = categoryToAmountExpense[categoryId]! - transaction.amount.toDouble();
+            categoryToAmountExpense[categoryId] =
+                categoryToAmountExpense[categoryId]! -
+                    transaction.amount.toDouble();
           } else {
-            categoryToAmountExpense.putIfAbsent(categoryId, () => -transaction.amount.toDouble());
+            categoryToAmountExpense.putIfAbsent(
+                categoryId, () => -transaction.amount.toDouble());
           }
         }
       }
@@ -77,10 +86,14 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
             const SizedBox(height: 16),
             categories.when(
               data: (data) {
-                List<CategoryTransaction> categoryIncomeList =
-                    data.where((category) => categoryToAmountIncome.containsKey(category.id)).toList();
-                List<CategoryTransaction> categoryExpenseList =
-                    data.where((category) => categoryToAmountExpense.containsKey(category.id)).toList();
+                List<CategoryTransaction> categoryIncomeList = data
+                    .where((category) =>
+                        categoryToAmountIncome.containsKey(category.id))
+                    .toList();
+                List<CategoryTransaction> categoryExpenseList = data
+                    .where((category) =>
+                        categoryToAmountExpense.containsKey(category.id))
+                    .toList();
                 return transactionType == TransactionType.income
                     ? categoryIncomeList.isEmpty
                         ? const SizedBox(
@@ -101,14 +114,24 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
                                 shrinkWrap: true,
                                 physics: const NeverScrollableScrollPhysics(),
                                 itemCount: categoryIncomeList.length,
-                                separatorBuilder: (context, index) => const SizedBox(height: 10),
+                                separatorBuilder: (context, index) =>
+                                    const SizedBox(height: 10),
                                 itemBuilder: (context, index) {
-                                  CategoryTransaction category = categoryIncomeList[index];
+                                  CategoryTransaction category =
+                                      categoryIncomeList[index];
                                   return CategoryListTile(
                                     category: category,
-                                    transactions: categoryToTransactionsIncome[category.id] ?? [],
-                                    amount: categoryToAmountIncome[category.id] ?? 0,
-                                    percent: (categoryToAmountIncome[category.id] ?? 0) / totalIncome * 100,
+                                    transactions: categoryToTransactionsIncome[
+                                            category.id] ??
+                                        [],
+                                    amount:
+                                        categoryToAmountIncome[category.id] ??
+                                            0,
+                                    percent:
+                                        (categoryToAmountIncome[category.id] ??
+                                                0) /
+                                            totalIncome *
+                                            100,
                                     index: index,
                                   );
                                 },
@@ -134,14 +157,24 @@ class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
                                 shrinkWrap: true,
                                 physics: const NeverScrollableScrollPhysics(),
                                 itemCount: categoryExpenseList.length,
-                                separatorBuilder: (context, index) => const SizedBox(height: 10),
+                                separatorBuilder: (context, index) =>
+                                    const SizedBox(height: 10),
                                 itemBuilder: (context, index) {
-                                  CategoryTransaction category = categoryExpenseList[index];
+                                  CategoryTransaction category =
+                                      categoryExpenseList[index];
                                   return CategoryListTile(
                                     category: category,
-                                    transactions: categoryToTransactionsExpense[category.id] ?? [],
-                                    amount: categoryToAmountExpense[category.id] ?? 0,
-                                    percent: (categoryToAmountExpense[category.id] ?? 0) / totalExpense * 100,
+                                    transactions: categoryToTransactionsExpense[
+                                            category.id] ??
+                                        [],
+                                    amount:
+                                        categoryToAmountExpense[category.id] ??
+                                            0,
+                                    percent:
+                                        (categoryToAmountExpense[category.id] ??
+                                                0) /
+                                            totalExpense *
+                                            100,
                                     index: index,
                                   );
                                 },

--- a/lib/pages/transactions_page/widgets/categories_tab.dart
+++ b/lib/pages/transactions_page/widgets/categories_tab.dart
@@ -23,7 +23,7 @@ class CategoriesTab extends ConsumerStatefulWidget {
 class _CategoriesTabState extends ConsumerState<CategoriesTab> with Functions {
   @override
   Widget build(BuildContext context) {
-    final categories = ref.watch(categoriesProvider(userCategoriesFilter));
+    final categories = ref.watch(categoriesProvider(allCategoriesFilter));
     final transactions = ref.watch(transactionsProvider);
     final transactionType = ref.watch(selectedTransactionTypeProvider);
 

--- a/test/model/category_transaction_test.dart
+++ b/test/model/category_transaction_test.dart
@@ -11,6 +11,7 @@ void main() {
         type: CategoryTransactionType.expense,
         symbol: "symbol",
         color: 0,
+        markedAsDeleted: false,
         createdAt: DateTime.utc(2022),
         updatedAt: DateTime.utc(2022));
 
@@ -21,6 +22,7 @@ void main() {
     assert(cCopy.type == c.type);
     assert(cCopy.symbol == c.symbol);
     assert(cCopy.color == c.color);
+    assert(cCopy.markedAsDeleted == c.markedAsDeleted);
     assert(cCopy.createdAt == c.createdAt);
     assert(cCopy.updatedAt == c.updatedAt);
   });
@@ -45,19 +47,21 @@ void main() {
     assert(c.symbol == json[CategoryTransactionFields.symbol]);
     assert(c.color == json[CategoryTransactionFields.color]);
     assert(c.note == json[CategoryTransactionFields.note]);
-    assert(c.createdAt?.toUtc().toIso8601String() == json[BaseEntityFields.createdAt]);
-    assert(c.updatedAt?.toUtc().toIso8601String() == json[BaseEntityFields.updatedAt]);
+    assert(c.createdAt?.toUtc().toIso8601String() ==
+        json[BaseEntityFields.createdAt]);
+    assert(c.updatedAt?.toUtc().toIso8601String() ==
+        json[BaseEntityFields.updatedAt]);
   });
 
   test("Test toJson Category Transaction", () {
     CategoryTransaction c = const CategoryTransaction(
-      id: 2,
-      name: "name",
-      type: CategoryTransactionType.expense,
-      symbol: "symbol",
-      color: 0,
-      note: "note",
-    );
+        id: 2,
+        name: "name",
+        type: CategoryTransactionType.expense,
+        symbol: "symbol",
+        color: 0,
+        note: "note",
+        markedAsDeleted: false);
 
     Map<String, Object?> json = c.toJson();
 
@@ -67,5 +71,7 @@ void main() {
     assert(c.symbol == json[CategoryTransactionFields.symbol]);
     assert(c.color == json[CategoryTransactionFields.color]);
     assert(c.note == json[CategoryTransactionFields.note]);
+    assert((c.markedAsDeleted ? 1 : 0) ==
+        json[CategoryTransactionFields.markedAsDeleted]);
   });
 }


### PR DESCRIPTION
### Description

In reference to the issue #177 
with this PR there is the possibility of deleting categories while retaining transactions and recurring transactions.
There are two ways:

- Mark a category as deleted: all old transactions will still be displayed everywhere, but it will not be possible to create new ones with the category marked
- Delete the category definitively: this converts all transactions and recurring transactions by changing the category to Uncategorized.


### Technical details

For IN and OUT, there are now two reserved “Uncategorized” system categories, with respective gray color, inserted within the color list.
These categories are not editable, but can be used, if there is a need to enter transactions without a specific category.

When trying to delete a category from the settings, a Dialog appears that looks like this:

![Delete Category](https://github.com/user-attachments/assets/8f4555b8-8c47-4687-adad-1eb46a569fef)

For @federicopozzato  and the design team, I tried to keep the style already used on other occasions. Free to come up with something more appealing (e.g., some loaders while the reassignment process proceeds), as well as the gray and the icon for the category “Uncategorized”

![Add category budget](https://github.com/user-attachments/assets/d370cd47-dada-4570-b235-bc2e40c8853e)

In the planning section, you cannot choose the “Uncategorized” category, since I think it is useless in this case. If there is a need for a separate category, you create it custom
