### PR TITLE
Fix #347

### DIFF
--- a/lib/pages/account_page/account_page.dart
+++ b/lib/pages/account_page/account_page.dart
@@ -20,12 +20,11 @@ class AccountPage extends ConsumerStatefulWidget {
 class _AccountPage extends ConsumerState<AccountPage> with Functions {
   bool isRecoinciling = false;
   final TextEditingController _newBalanceController = TextEditingController();
-
-  FocusNode focusNode = FocusNode();
+  final FocusNode _focusNode = FocusNode();
 
   @override
   void dispose() {
-    focusNode.dispose();
+    _focusNode.dispose();
     _newBalanceController.dispose();
     super.dispose();
   }
@@ -99,7 +98,7 @@ class _AccountPage extends ConsumerState<AccountPage> with Functions {
                       Column(
                         children: [
                           TextField(
-                            focusNode: focusNode,
+                            _focusNode: _focusNode,
                             controller: _newBalanceController,
                             decoration: InputDecoration(
                                 hintText: "New Balance",
@@ -170,7 +169,7 @@ class _AccountPage extends ConsumerState<AccountPage> with Functions {
                       TextButton.icon(
                           onPressed: () {
                             setState(() => isRecoinciling = true);
-                            focusNode.requestFocus();
+                            _focusNode.requestFocus();
                           },
                           icon: const Icon(Icons.sync),
                           label: Text(

--- a/lib/pages/account_page/account_page.dart
+++ b/lib/pages/account_page/account_page.dart
@@ -98,7 +98,7 @@ class _AccountPage extends ConsumerState<AccountPage> with Functions {
                       Column(
                         children: [
                           TextField(
-                            _focusNode: _focusNode,
+                            focusNode: _focusNode,
                             controller: _newBalanceController,
                             decoration: InputDecoration(
                                 hintText: "New Balance",

--- a/lib/pages/account_page/account_page.dart
+++ b/lib/pages/account_page/account_page.dart
@@ -26,6 +26,7 @@ class _AccountPage extends ConsumerState<AccountPage> with Functions {
   @override
   void dispose() {
     focusNode.dispose();
+    _newBalanceController.dispose();
     super.dispose();
   }
 

--- a/lib/pages/planning_page/widget/budget_category_selector.dart
+++ b/lib/pages/planning_page/widget/budget_category_selector.dart
@@ -45,6 +45,12 @@ class _BudgetCategorySelector extends ConsumerState<BudgetCategorySelector> {
   }
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Container(
       padding: const EdgeInsets.all(16),

--- a/lib/pages/planning_page/widget/edit_recurring_transaction.dart
+++ b/lib/pages/planning_page/widget/edit_recurring_transaction.dart
@@ -35,6 +35,13 @@ class _EditRecurringTransactionState
   }
 
   @override
+  void dispose() {
+    amountController.dispose();
+    noteController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final selectedRecurringTransaction =
         ref.watch(selectedRecurringTransactionUpdateProvider);


### PR DESCRIPTION
Closes #347 

This PR includes several changes to improve resource management by ensuring proper disposal of controllers and focus nodes in various widgets.

Resource management improvements:

* [`lib/pages/account_page/account_page.dart`](diffhunk://#diff-d64123ab0accd276ab45aad13e47560bb9c2e4aa958cb39ca9e545252e5a106eL23-R28): Changed `focusNode` to `_focusNode` and ensured both `_focusNode` and `_newBalanceController` are disposed of in the `dispose` method. Updated references to use `_focusNode`. [[1]](diffhunk://#diff-d64123ab0accd276ab45aad13e47560bb9c2e4aa958cb39ca9e545252e5a106eL23-R28) [[2]](diffhunk://#diff-d64123ab0accd276ab45aad13e47560bb9c2e4aa958cb39ca9e545252e5a106eL101-R101) [[3]](diffhunk://#diff-d64123ab0accd276ab45aad13e47560bb9c2e4aa958cb39ca9e545252e5a106eL172-R172)
* [`lib/pages/planning_page/widget/budget_category_selector.dart`](diffhunk://#diff-99e32fc99a2c90b14b115a968d116a3c5395a4427dd856550dfdd84b4c374899R47-R52): Added a `dispose` method to ensure `_controller` is disposed of properly.
* [`lib/pages/planning_page/widget/edit_recurring_transaction.dart`](diffhunk://#diff-97598030998fbd31e13ece2a570e390d2020cff3bac636e1d8d3c880ac2fbab0R37-R43): Added a `dispose` method to ensure `amountController` and `noteController` are disposed of properly.