### PR TITLE
feat(transactions): enable recurring transactions for Income and Transfers

### DIFF
--- a/lib/database/migrations/0001_initial_schema.dart
+++ b/lib/database/migrations/0001_initial_schema.dart
@@ -11,10 +11,7 @@ import '/model/transaction.dart';
 
 class InitialSchema extends Migration {
   InitialSchema()
-      : super(
-          version: 1,
-          description: 'Initial database schema creation',
-        );
+      : super(version: 1, description: 'Initial database schema creation');
 
   @override
   Future<void> up(Database db) async {

--- a/lib/database/migrations/0002_account_net_worth.dart
+++ b/lib/database/migrations/0002_account_net_worth.dart
@@ -6,10 +6,7 @@ import '/model/bank_account.dart';
 
 class AccountNetWorth extends Migration {
   AccountNetWorth()
-      : super(
-          version: 2,
-          description: 'Add account net worth column',
-        );
+      : super(version: 2, description: 'Add account net worth column');
 
   @override
   Future<void> up(Database db) async {

--- a/lib/database/migrations/0003_recurring_transaction_type.dart
+++ b/lib/database/migrations/0003_recurring_transaction_type.dart
@@ -1,0 +1,21 @@
+import 'package:sqflite/sqflite.dart';
+import '../migration_base.dart';
+
+// Models
+import '/model/recurring_transaction.dart';
+
+class RecurringTransactionType extends Migration {
+  RecurringTransactionType()
+      : super(
+            version: 3, description: 'Add type to recurring transaction table');
+
+  @override
+  Future<void> up(Database db) async {
+    const realNotNull = 'REAL NOT NULL';
+
+    // Bank accounts Table
+    await db.execute('''
+      ALTER TABLE `$recurringTransactionTable` ADD COLUMN `${RecurringTransactionFields.type}` $realNotNull;
+      ''');
+  }
+}

--- a/lib/database/migrations/migration_registry.dart
+++ b/lib/database/migrations/migration_registry.dart
@@ -13,6 +13,7 @@ library;
 
 import '0001_initial_schema.dart';
 import '0002_account_net_worth.dart';
+import '0003_recurring_transaction_type.dart';
 import '../migration_base.dart';
 
 /// Returns all available migrations in execution order.
@@ -25,6 +26,7 @@ List<Migration> getMigrations() {
   return [
     InitialSchema(),
     AccountNetWorth(),
+    RecurringTransactionType(),
     // Add future migrations here
   ];
 }

--- a/lib/database/sossoldi_database.dart
+++ b/lib/database/sossoldi_database.dart
@@ -231,10 +231,10 @@ class SossoldiDatabase {
 
     // Add fake recurring transactions
     await _database?.execute('''
-      INSERT INTO recurringTransaction(fromDate, toDate, amount, note, recurrency, idCategory, idBankAccount, createdAt, updatedAt) VALUES
-        ("2024-02-23", null, 10.99, "404 Books", "MONTHLY", 14, 70, '${DateTime.now()}', '${DateTime.now()}'),
-        ("2023-12-13", null, 4.97, "ETF Consultant Parcel", "DAILY", 14, 70, '${DateTime.now()}', '${DateTime.now()}'),
-        ("2023-02-11", "2028-02-11", 1193.40, "Car Loan", "QUARTERLY", 15, 72, '${DateTime.now()}', '${DateTime.now()}');
+      INSERT INTO recurringTransaction(fromDate, toDate, amount,type, note, recurrency, idCategory, idBankAccount, createdAt, updatedAt) VALUES
+        ("2024-02-23", null, 10.99, "OUT", "404 Books", "MONTHLY", 14, 70, '${DateTime.now()}', '${DateTime.now()}'),
+        ("2023-12-13", null, 4.97, "OUT", "ETF Consultant Parcel", "DAILY", 14, 70, '${DateTime.now()}', '${DateTime.now()}'),
+        ("2023-02-11", "2028-02-11", 1193.40, "OUT", "Car Loan", "QUARTERLY", 15, 72, '${DateTime.now()}', '${DateTime.now()}');
     ''');
 
     // Add fake transactions

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,9 +49,7 @@ void main() async {
     RecurringTransactionMethods().checkRecurringTransactions();
     // update last recurring transactions runtime
     await _sharedPreferences.setString(
-      'last_recurring_transactions_check',
-      DateTime.now().toIso8601String(),
-    );
+        'last_recurring_transactions_check', DateTime.now().toIso8601String());
   }
 
   initializeDateFormatting('it_IT', null).then(

--- a/lib/model/currency.dart
+++ b/lib/model/currency.dart
@@ -33,14 +33,13 @@ class Currency extends BaseEntity {
     required this.mainCurrency,
   });
 
-  Currency copy({
-    int? id,
-    String? symbol,
-    String? code,
-    String? name,
-    bool? mainCurrency,
-    t,
-  }) =>
+  Currency copy(
+          {int? id,
+          String? symbol,
+          String? code,
+          String? name,
+          bool? mainCurrency,
+          t}) =>
       Currency(
         id: id ?? this.id,
         symbol: symbol ?? this.symbol,
@@ -82,12 +81,11 @@ class CurrencyMethods extends SossoldiDatabase {
     } else {
       //fallback
       return const Currency(
-        id: 2,
-        symbol: '\$',
-        code: 'USD',
-        name: "United States Dollar",
-        mainCurrency: true,
-      );
+          id: 2,
+          symbol: '\$',
+          code: 'USD',
+          name: "United States Dollar",
+          mainCurrency: true);
     }
   }
 

--- a/lib/model/recurring_transaction.dart
+++ b/lib/model/recurring_transaction.dart
@@ -10,6 +10,7 @@ class RecurringTransactionFields extends BaseEntityFields {
   static String toDate = 'toDate';
   static String amount = 'amount';
   static String note = 'note';
+  static String type = 'type';
   static String recurrency = 'recurrency';
   static String idCategory = 'idCategory';
   static String idBankAccount = 'idBankAccount';
@@ -50,69 +51,74 @@ class RecurringTransaction extends BaseEntity {
   final String recurrency;
   final int idCategory;
   final int idBankAccount;
+  final TransactionType type;
   final DateTime? lastInsertion;
 
-  const RecurringTransaction({
-    super.id,
-    required this.fromDate,
-    this.toDate,
-    required this.amount,
-    required this.note,
-    required this.recurrency,
-    required this.idCategory,
-    required this.idBankAccount,
-    this.lastInsertion,
-    super.createdAt,
-    super.updatedAt,
-  });
+  const RecurringTransaction(
+      {super.id,
+      required this.fromDate,
+      this.toDate,
+      required this.amount,
+      required this.note,
+      required this.recurrency,
+      required this.idCategory,
+      required this.type,
+      required this.idBankAccount,
+      this.lastInsertion,
+      super.createdAt,
+      super.updatedAt});
 
-  RecurringTransaction copy({
-    int? id,
-    DateTime? fromDate,
-    DateTime? toDate,
-    num? amount,
-    String? note,
-    String? recurrency,
-    int? idCategory,
-    int? idBankAccount,
-    DateTime? lastInsertion,
-    DateTime? createdAt,
-    DateTime? updatedAt,
-  }) =>
+  RecurringTransaction copy(
+          {int? id,
+          DateTime? fromDate,
+          DateTime? toDate,
+          num? amount,
+          String? note,
+          String? recurrency,
+          int? idCategory,
+          TransactionType? type,
+          int? idBankAccount,
+          DateTime? lastInsertion,
+          DateTime? createdAt,
+          DateTime? updatedAt}) =>
       RecurringTransaction(
-        id: id ?? this.id,
-        fromDate: fromDate ?? this.fromDate,
-        toDate: toDate ?? this.toDate,
-        amount: amount ?? this.amount,
-        note: note ?? this.note,
-        recurrency: recurrency ?? this.recurrency,
-        idCategory: idCategory ?? this.idCategory,
-        idBankAccount: idBankAccount ?? this.idBankAccount,
-        lastInsertion: lastInsertion ?? this.lastInsertion,
-        createdAt: createdAt ?? this.createdAt,
-        updatedAt: updatedAt ?? this.updatedAt,
-      );
+          id: id ?? this.id,
+          fromDate: fromDate ?? this.fromDate,
+          toDate: toDate ?? this.toDate,
+          amount: amount ?? this.amount,
+          note: note ?? this.note,
+          recurrency: recurrency ?? this.recurrency,
+          idCategory: idCategory ?? this.idCategory,
+          type: type ?? this.type,
+          idBankAccount: idBankAccount ?? this.idBankAccount,
+          lastInsertion: lastInsertion ?? this.lastInsertion,
+          createdAt: createdAt ?? this.createdAt,
+          updatedAt: updatedAt ?? this.updatedAt);
 
   static RecurringTransaction fromJson(Map<String, Object?> json) =>
       RecurringTransaction(
-        id: json[BaseEntityFields.id] as int?,
-        fromDate:
-            DateTime.parse(json[RecurringTransactionFields.fromDate] as String),
-        toDate: json[RecurringTransactionFields.toDate] != null
-            ? DateTime.parse(json[RecurringTransactionFields.toDate] as String)
-            : null,
-        amount: json[RecurringTransactionFields.amount] as num,
-        note: json[RecurringTransactionFields.note] as String,
-        recurrency: json[RecurringTransactionFields.recurrency] as String,
-        idCategory: json[RecurringTransactionFields.idCategory] as int,
-        idBankAccount: json[RecurringTransactionFields.idBankAccount] as int,
-        lastInsertion: json[RecurringTransactionFields.lastInsertion] != null
-            ? DateTime.parse(
-                json[RecurringTransactionFields.lastInsertion] as String)
-            : null,
-        createdAt: DateTime.parse(json[BaseEntityFields.createdAt] as String),
-        updatedAt: DateTime.parse(json[BaseEntityFields.updatedAt] as String),
-      );
+          id: json[BaseEntityFields.id] as int?,
+          fromDate: DateTime.parse(
+              json[RecurringTransactionFields.fromDate] as String),
+          toDate:
+              json[RecurringTransactionFields.toDate] != null
+                  ? DateTime.parse(
+                      json[RecurringTransactionFields.toDate] as String)
+                  : null,
+          amount: json[RecurringTransactionFields.amount] as num,
+          note: json[RecurringTransactionFields.note] as String,
+          recurrency: json[RecurringTransactionFields.recurrency] as String,
+          idCategory: json[RecurringTransactionFields.idCategory] as int,
+          type: TransactionType.fromJson(
+              json[RecurringTransactionFields.type] as String),
+          idBankAccount: json[RecurringTransactionFields.idBankAccount] as int,
+          lastInsertion: json[RecurringTransactionFields.lastInsertion] != null
+              ? DateTime.parse(
+                  json[RecurringTransactionFields.lastInsertion] as String)
+              : null,
+          createdAt: DateTime.parse(json[BaseEntityFields.createdAt] as String),
+          updatedAt:
+              DateTime.parse(json[BaseEntityFields.updatedAt] as String));
 
   Map<String, Object?> toJson() => {
         BaseEntityFields.id: id,
@@ -120,6 +126,7 @@ class RecurringTransaction extends BaseEntity {
         RecurringTransactionFields.toDate: toDate?.toIso8601String(),
         RecurringTransactionFields.amount: amount,
         RecurringTransactionFields.note: note,
+        RecurringTransactionFields.type: type.toJson(),
         RecurringTransactionFields.recurrency: recurrency,
         RecurringTransactionFields.idCategory: idCategory,
         RecurringTransactionFields.idBankAccount: idBankAccount,
@@ -303,7 +310,7 @@ class RecurringTransactionMethods extends SossoldiDatabase {
           break;
         case 'months':
           // get the last day of the next period
-          int lastDayOfNextPeriod = DateTime(lastTransactionDate.year,
+          final int lastDayOfNextPeriod = DateTime(lastTransactionDate.year,
                   (lastTransactionDate.month + amount + 1), 0)
               .day;
           int dayOfInsertion = transaction.fromDate.day;
@@ -330,11 +337,10 @@ class RecurringTransactionMethods extends SossoldiDatabase {
 
     for (var tr in transactions2Add) {
       // insert a new transaction
-
       Transaction addTr = Transaction(
         date: tr,
         amount: transaction.amount,
-        type: TransactionType.expense,
+        type: transaction.type,
         note: transaction.note,
         idCategory: transaction.idCategory,
         idBankAccount: transaction.idBankAccount,

--- a/lib/pages/add_page/add_page.dart
+++ b/lib/pages/add_page/add_page.dart
@@ -42,7 +42,6 @@ class _AddPageState extends ConsumerState<AddPage> {
         ref.read(selectedTransactionUpdateProvider)?.amount.toCurrency() ?? '';
     noteController.text =
         ref.read(selectedTransactionUpdateProvider)?.note ?? '';
-
     amountController.addListener(_updateAmount);
 
     super.initState();
@@ -151,7 +150,8 @@ class _AddPageState extends ConsumerState<AddPage> {
             !selectedTransaction.recurring) {
           ref
               .read(transactionsProvider.notifier)
-              .addRecurringTransaction(cleanAmount.toNum(), noteController.text)
+              .addRecurringTransaction(
+                  cleanAmount.toNum(), noteController.text, selectedType)
               .then((value) {
             if (value != null) {
               ref
@@ -183,7 +183,7 @@ class _AddPageState extends ConsumerState<AddPage> {
               ref
                   .read(transactionsProvider.notifier)
                   .addRecurringTransaction(
-                      cleanAmount.toNum(), noteController.text)
+                      cleanAmount.toNum(), noteController.text, selectedType)
                   .whenComplete(() => _refreshAccountAndNavigateBack());
             } else {
               ref
@@ -374,14 +374,12 @@ class _AddPageState extends ConsumerState<AddPage> {
                             }
                           },
                         ),
-                        if (selectedType == TransactionType.expense) ...[
-                          RecurrenceListTile(
-                            recurrencyEditingPermitted:
-                                widget.recurrencyEditingPermitted,
-                            selectedTransaction:
-                                ref.read(selectedTransactionUpdateProvider),
-                          )
-                        ],
+                        RecurrenceListTile(
+                          recurrencyEditingPermitted:
+                              widget.recurrencyEditingPermitted,
+                          selectedTransaction:
+                              ref.read(selectedTransactionUpdateProvider),
+                        )
                       ],
                     ),
                   ),

--- a/lib/pages/add_page/widgets/amount_widget.dart
+++ b/lib/pages/add_page/widgets/amount_widget.dart
@@ -27,6 +27,7 @@ class _AmountWidgetState extends ConsumerState<AmountWidget> {
   Widget build(BuildContext context) {
     final selectedType = ref.watch(transactionTypeProvider);
     final currencyState = ref.watch(currencyStateNotifier);
+    final selectedTransaction = ref.read(selectedTransactionUpdateProvider);
 
     return Padding(
       padding:

--- a/lib/pages/planning_page/widget/recurring_payment_card.dart
+++ b/lib/pages/planning_page/widget/recurring_payment_card.dart
@@ -42,10 +42,10 @@ class RecurringPaymentCard extends ConsumerWidget {
     final isDarkMode = ref.watch(appThemeStateNotifier).isDarkModeEnabled;
     final currencyState = ref.watch(currencyStateNotifier);
 
-    var cat = categories
+    var category = categories
         ?.firstWhereOrNull((element) => element.id == transaction.idCategory);
 
-    return cat != null
+    return category != null
         ? Container(
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(Sizes.borderRadius),
@@ -56,7 +56,7 @@ class RecurringPaymentCard extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(
                   horizontal: Sizes.sm, vertical: Sizes.md),
               decoration: BoxDecoration(
-                color: categoryColorList[cat.color].withValues(alpha: 0.2),
+                color: categoryColorList[category.color].withValues(alpha: 0.2),
                 borderRadius: BorderRadius.circular(Sizes.borderRadius),
               ),
               child: Column(
@@ -65,8 +65,8 @@ class RecurringPaymentCard extends ConsumerWidget {
                   Row(
                     children: [
                       RoundedIcon(
-                        icon: iconList[cat.symbol],
-                        backgroundColor: categoryColorList[cat.color],
+                        icon: iconList[category.symbol],
+                        backgroundColor: categoryColorList[category.color],
                         padding: const EdgeInsets.all(Sizes.sm),
                         size: 25,
                       ),
@@ -93,7 +93,7 @@ class RecurringPaymentCard extends ConsumerWidget {
                                 ),
                               ),
                               const SizedBox(height: Sizes.sm),
-                              Text(cat.name),
+                              Text(category.name),
                             ],
                           )),
                       Expanded(
@@ -103,15 +103,24 @@ class RecurringPaymentCard extends ConsumerWidget {
                           mainAxisAlignment: MainAxisAlignment.end,
                           children: [
                             Text("In ${getNextText()} days"),
-                            const SizedBox(height: Sizes.sm),
+                            const SizedBox(height: 10),
+                            Builder(builder: (context) {
+                              final String prefix = transaction.type.prefix;
+                              final Color amountColor = transaction.type
+                                  .toColor(
+                                      brightness: Theme.of(context).brightness);
+                              return Text(
+                                "$prefix${transaction.amount}${currencyState.selectedCurrency.symbol}",
+                                style: TextStyle(color: amountColor),
+                              );
+                            }),
+                            const SizedBox(height: 10),
                             Text(
-                                "-${transaction.amount}${currencyState.selectedCurrency.symbol}",
-                                style: const TextStyle(color: Colors.red)),
-                            const SizedBox(height: Sizes.sm),
-                            Text(accounts!
-                                .firstWhere((element) =>
-                                    element.id == transaction.idBankAccount)
-                                .name),
+                              accounts!
+                                  .firstWhere((element) =>
+                                      element.id == transaction.idBankAccount)
+                                  .name,
+                            ),
                           ],
                         ),
                       ),

--- a/lib/ui/widgets/budget_circular_indicator.dart
+++ b/lib/ui/widgets/budget_circular_indicator.dart
@@ -23,7 +23,7 @@ class BudgetCircularIndicator extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currencyState = ref.watch(currencyStateNotifier);
-
+    final theme = Theme.of(context);
     return Column(
       children: [
         CircularPercentIndicator(
@@ -61,10 +61,8 @@ class BudgetCircularIndicator extends ConsumerWidget {
               const SizedBox(height: Sizes.sm),
               Text(
                 "LEFT",
-                style: Theme.of(context)
-                    .textTheme
-                    .labelLarge!
-                    .copyWith(color: Theme.of(context).colorScheme.primary),
+                style: theme.textTheme.labelLarge!
+                    .copyWith(color: theme.colorScheme.primary),
               ),
             ],
           ),

--- a/test/model/recurring_transaction_test.dart
+++ b/test/model/recurring_transaction_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:sossoldi/model/recurring_transaction.dart';
 import 'package:sossoldi/model/base_entity.dart';
+import 'package:sossoldi/model/transaction.dart';
 
 void main() {
   test('Test Copy Recurring Transaction Amount', () {
@@ -13,6 +14,7 @@ void main() {
         amount: 14,
         note: 'Test Transaction',
         recurrency: 'MONTHLY',
+        type: TransactionType.expense,
         idBankAccount: 34,
         idCategory: 24,
         createdAt: DateTime.utc(2022),
@@ -41,6 +43,7 @@ void main() {
       RecurringTransactionFields.note: "Test Transaction",
       RecurringTransactionFields.recurrency: "WEEKLY",
       RecurringTransactionFields.idBankAccount: 44,
+      RecurringTransactionFields.type: "OUT",
       RecurringTransactionFields.idCategory: 4,
       BaseEntityFields.createdAt: DateTime.utc(2022).toIso8601String(),
       BaseEntityFields.updatedAt: DateTime.utc(2022).toIso8601String(),
@@ -70,6 +73,7 @@ void main() {
         fromDate: DateTime.utc(2022),
         toDate: DateTime.utc(2023),
         amount: 0,
+        type: TransactionType.expense,
         note: "Test transaction",
         recurrency: "MONTHLY",
         idBankAccount: 4,


### PR DESCRIPTION
Recurring transactions were previously limited to Expenses.
This update allows recurring transactions to be used for Income and Transfers as well.


I noticed a problem, albeit non-blocking: the color of the selected transaction remains persistent even after the type change via the top button. This happens because the fallback value of the type is determined by the parameter passed to the function.

I chose not to intervene in this aspect because, given the current state management model, it would be necessary to rethink the assignment of the transaction type to the provider. The goal would be to ensure consistent management in line with the Single Source of Truth principle, avoiding duplication or inconsistent state.

#199 