### PR TITLE
chore: Resolve #356 - Reworked currency selector in General Settings

### DIFF
--- a/lib/pages/general_options/general_settings.dart
+++ b/lib/pages/general_options/general_settings.dart
@@ -3,7 +3,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../constants/style.dart';
 import '../../model/currency.dart';
-import '../../providers/currency_provider.dart';
 import '../../providers/theme_provider.dart';
 import 'widgets/currency_selector.dart';
 
@@ -32,7 +31,6 @@ class _GeneralSettingsPageState extends ConsumerState<GeneralSettingsPage> {
   @override
   Widget build(BuildContext context) {
     final appThemeState = ref.watch(appThemeStateNotifier);
-    final currencyState = ref.watch(currencyStateNotifier);
 
     return Scaffold(
       appBar: AppBar(
@@ -77,32 +75,7 @@ class _GeneralSettingsPageState extends ConsumerState<GeneralSettingsPage> {
               ],
             ),
             const SizedBox(height: 20),
-            Row(
-              children: [
-                Text("Currency",
-                    style: Theme.of(context)
-                        .textTheme
-                        .titleLarge!
-                        .copyWith(color: Theme.of(context).colorScheme.primary)),
-                const Spacer(),
-                GestureDetector(
-                    onTap: () {
-                      setState(() {
-                        CurrencySelectorDialog.selectCurrencyDialog(
-                            context, currencyState, currencyList);
-                      });
-                    },
-                    child: CircleAvatar(
-                        radius: 30.0,
-                        backgroundColor: blue5,
-                        child: Center(
-                            child: Text(
-                          currencyState.selectedCurrency.symbol,
-                          style: TextStyle(
-                              color: Theme.of(context).colorScheme.onPrimary, fontSize: 25),
-                        )))),
-              ],
-            ),
+            SettingsCurrencySelector(),
             const SizedBox(height: 20),
             /*
             Row(

--- a/lib/pages/general_options/widgets/currency_selector.dart
+++ b/lib/pages/general_options/widgets/currency_selector.dart
@@ -1,76 +1,71 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
 
-import '../../../constants/style.dart';
 import '../../../model/currency.dart';
 import '../../../providers/currency_provider.dart';
+import 'selector/selector_container.dart';
+import 'selector/selector_tile.dart';
 
-class CurrencySelectorDialog {
-  static void selectCurrencyDialog(
-      BuildContext context, CurrencyState state, Future<List<Currency>> currencies) {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(
-          'Select a currency',
-          style: Theme.of(context)
-              .textTheme
-              .titleLarge!
-              .copyWith(color: Theme.of(context).colorScheme.primary),
-        ),
-        content: SizedBox(
-          height: 300,
-          width: 220,
-          child: SingleChildScrollView(
-            child: FutureBuilder(
-                future: currencies,
-                builder: (context, snapshot) {
-                  if (snapshot.hasData &&
-                      snapshot.data != null &&
-                      snapshot.connectionState == ConnectionState.done) {
-                    return ListView.builder(
-                      itemCount: snapshot.data!.length,
-                      physics: const NeverScrollableScrollPhysics(),
-                      shrinkWrap: true,
-                      itemBuilder: (BuildContext context, int i) {
-                        return GestureDetector(
-                          onTap: () {
-                            state.setSelectedCurrency(snapshot.data![i]);
-                            Navigator.pop(context);
-                          },
-                          child: ListTile(
-                            leading: CircleAvatar(
-                              radius: 22,
-                              backgroundColor: state.selectedCurrency.code == snapshot.data![i].code
-                                  ? blue5
-                                  : grey1,
-                              child: Text(snapshot.data![i].symbol,
-                                  style: TextStyle(
-                                      color: Theme.of(context).colorScheme.onPrimary,
-                                      fontSize: 20)),
-                            ),
-                            title: Text(
-                              snapshot.data![i].name,
-                              textAlign: TextAlign.center,
-                            ),
-                          ),
-                        );
-                      },
-                    );
-                  } else if (snapshot.hasError) {
-                    return Text('Something went wrong: ${snapshot.error}');
-                  } else {
-                    if (snapshot.connectionState == ConnectionState.waiting) {
-                      return Transform.scale(
-                        scale: 0.5,
-                        child: const CircularProgressIndicator(),
-                      );
-                    } else {
-                      return const Text("Search for a transaction");
-                    }
-                  }
-                }),
-          ),
-        ),
+class SettingsCurrencySelector extends ConsumerStatefulWidget {
+  const SettingsCurrencySelector({super.key});
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _SettingsCurrencySelectorState();
+}
+
+class _SettingsCurrencySelectorState
+    extends ConsumerState<SettingsCurrencySelector> {
+  final currenciesFuture = CurrencyMethods().selectAll();
+
+  @override
+  Widget build(BuildContext context) {
+    final currencyState = ref.watch(currencyStateNotifier);
+
+    return SelectorContainer(
+      label: 'SELECT A CURRENCY',
+      child: FutureBuilder(
+        future: currenciesFuture,
+        builder: (context, snapshot) {
+          if (snapshot.hasData &&
+              snapshot.data != null &&
+              snapshot.connectionState == ConnectionState.done) {
+            final currencies = snapshot.data;
+
+            return ListView.separated(
+              separatorBuilder: (context, index) {
+                return Gap(8);
+              },
+              shrinkWrap: true,
+              itemCount: currencies!.length,
+              itemBuilder: (context, index) {
+                final selected = currencyState.selectedCurrency.code ==
+                    currencies[index].code;
+
+                return SelectorTile(
+                  onTap: () {
+                    currencyState.setSelectedCurrency(currencies[index]);
+                  },
+                  title: currencies[index].name,
+                  trailing: currencies[index].symbol,
+                  isSelected: selected,
+                );
+              },
+            );
+          } else if (snapshot.hasError) {
+            return Text('Something went wrong: ${snapshot.error}');
+          } else {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return Transform.scale(
+                scale: 0.5,
+                child: const CircularProgressIndicator(),
+              );
+            } else {
+              return const Text("Search for a transaction");
+            }
+          }
+        },
       ),
     );
   }

--- a/lib/pages/general_options/widgets/selector/selector_container.dart
+++ b/lib/pages/general_options/widgets/selector/selector_container.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:gap/gap.dart';
+
+class SelectorContainer extends StatelessWidget {
+  final String? label;
+  final Widget? child;
+
+  const SelectorContainer({
+    this.label,
+    this.child,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final appTheme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(4),
+        color: appTheme.colorScheme.surface,
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (label != null && label!.isNotEmpty) ...[
+            Text(
+              label!.toUpperCase(),
+              style: appTheme.textTheme.labelMedium,
+            ),
+            Gap(8),
+          ],
+          child ?? const SizedBox.shrink(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/general_options/widgets/selector/selector_tile.dart
+++ b/lib/pages/general_options/widgets/selector/selector_tile.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:gap/gap.dart';
+
+import '../../../../constants/style.dart';
+
+class SelectorTile extends ConsumerWidget {
+  final String title;
+  final String? trailing;
+  final Widget? trailingWidget;
+  final bool isSelected;
+  final VoidCallback? onTap;
+
+  const SelectorTile({
+    required this.title,
+    this.trailing,
+    this.trailingWidget,
+    this.isSelected = false,
+    this.onTap,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appTheme = Theme.of(context);
+
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        foregroundDecoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(4),
+          border: Border.all(
+            width: isSelected ? 1.0 : .5,
+            color: isSelected ? appTheme.colorScheme.onSurfaceVariant : grey2,
+          ),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                title,
+                style: appTheme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: isSelected ? FontWeight.w700 : FontWeight.w400,
+                  color: isSelected
+                      ? appTheme.colorScheme.onSurfaceVariant
+                      : appTheme.colorScheme.onSurface,
+                ),
+              ),
+            ),
+            Gap(8.0),
+            if (trailing != null) ...[
+              Text(
+                trailing!,
+                style: appTheme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: isSelected ? FontWeight.w700 : FontWeight.w400,
+                  color: isSelected
+                      ? appTheme.colorScheme.onSurfaceVariant
+                      : appTheme.colorScheme.onSurface,
+                ),
+              ),
+            ],
+            if (trailing == null && trailingWidget != null) trailingWidget!,
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -373,6 +373,7 @@ ColorScheme customColorScheme = const ColorScheme(
   onPrimary: white,
   onSecondary: white,
   onSurface: blue1,
+  onSurfaceVariant: blue5,
   onError: black,
   brightness: Brightness.light,
 );
@@ -388,6 +389,7 @@ ColorScheme darkCustomColorScheme = const ColorScheme(
   onPrimary: darkWhite,
   onSecondary: white,
   onSurface: darkBlue1,
+  onSurfaceVariant: darkBlue6,
   onError: darkBlack,
   brightness: Brightness.dark,
 );

--- a/test/test_utils/tester_extension.dart
+++ b/test/test_utils/tester_extension.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+extension $WidgetTester on WidgetTester {
+  Future<void> pumpWidgetWithMaterialApp(
+    Widget widget, {
+    Duration? duration,
+    EnginePhase phase = EnginePhase.sendSemanticsUpdate,
+    bool wrapWithView = true,
+    bool hasProviderScope = true,
+  }) {
+    return pumpWidget(
+      hasProviderScope
+          ? MaterialApp(
+              home: Material(
+                child: ProviderScope(
+                  child: widget,
+                ),
+              ),
+            )
+          : MaterialApp(
+              home: Material(
+                child: widget,
+              ),
+            ),
+      duration: duration,
+      phase: phase,
+      wrapWithView: wrapWithView,
+    );
+  }
+}

--- a/test/widget/selector_tile_widget_test.dart
+++ b/test/widget/selector_tile_widget_test.dart
@@ -1,0 +1,406 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/constants/style.dart';
+import 'package:sossoldi/pages/general_options/widgets/selector/selector_tile.dart';
+import 'package:sossoldi/utils/app_theme.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+import '../test_utils/tester_extension.dart';
+
+void main() {
+  databaseFactory = databaseFactoryFfiNoIsolate;
+
+  const selectorTileKey = Key('selectorTileKey');
+  const selectorTileTitle = 'Title';
+
+  Widget selectorTileWidget({
+    bool isSelected = false,
+    String? trailing,
+    Widget? trailingWidget,
+    VoidCallback? onTap,
+  }) {
+    return SelectorTile(
+      key: selectorTileKey,
+      title: selectorTileTitle,
+      trailing: trailing,
+      trailingWidget: trailingWidget,
+      onTap: onTap,
+      isSelected: isSelected,
+    );
+  }
+
+  testWidgets(
+    'GIVEN an SelectorTile widget '
+    'THEN it can be found by its key',
+    (WidgetTester tester) async {
+      await tester.pumpWidgetWithMaterialApp(selectorTileWidget());
+
+      final findSelectorTileKey = find.byKey(selectorTileKey);
+      expect(findSelectorTileKey, findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'GIVEN an SelectorTile widget '
+    'WHEN title is not null '
+    'THEN the title can be found',
+    (WidgetTester tester) async {
+      await tester.pumpWidgetWithMaterialApp(
+        selectorTileWidget(),
+      );
+
+      final findSelectorTileTitle = find.text(selectorTileTitle);
+      expect(findSelectorTileTitle, findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'GIVEN an SelectorTile widget '
+    'WHEN onTap is not null '
+    'THEN completer is completed',
+    (WidgetTester tester) async {
+      final completer = Completer<void>();
+
+      await tester.pumpWidgetWithMaterialApp(
+        selectorTileWidget(
+          onTap: completer.complete,
+        ),
+      );
+
+      final findSelectorTileKey = find.byKey(selectorTileKey);
+
+      expect(completer.isCompleted, isFalse);
+      await tester.tap(findSelectorTileKey);
+      expect(completer.isCompleted, isTrue);
+    },
+  );
+
+  testWidgets(
+    'GIVEN an SelectorTile widget '
+    'WHEN trailing is not null '
+    'THEN trailing is found',
+    (WidgetTester tester) async {
+      const trailingString = 'Trailing';
+
+      await tester.pumpWidgetWithMaterialApp(
+        selectorTileWidget(
+          trailing: trailingString,
+        ),
+      );
+
+      final findTrailingString = find.text(trailingString);
+      expect(findTrailingString, findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'GIVEN an SelectorTile widget '
+    'WHEN trailingWidget is not null '
+    'THEN trailingWidget is found',
+    (WidgetTester tester) async {
+      const trailingKey = Key('trailingKey');
+      const trailingString = SizedBox(key: trailingKey);
+
+      await tester.pumpWidgetWithMaterialApp(
+        selectorTileWidget(
+          trailingWidget: trailingString,
+        ),
+      );
+
+      final findTrailingWidget = find.byKey(trailingKey);
+      expect(findTrailingWidget, findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'GIVEN an SelectorTile widget '
+    'WHEN isSelected is false '
+    'THEN border width is 0.5',
+    (WidgetTester tester) async {
+      const unselectedBorderWidth = .5;
+
+      await tester.pumpWidgetWithMaterialApp(
+        selectorTileWidget(),
+      );
+
+      final findSelectorTile = find.byKey(selectorTileKey);
+      final findSelectorTileDescendants = find.descendant(
+          of: findSelectorTile, matching: find.byType(Container));
+
+      final selectorTileContainer =
+          findSelectorTileDescendants.evaluate().first.widget as Container;
+      final selectorTileBoxDecoration =
+          selectorTileContainer.foregroundDecoration as BoxDecoration;
+      final selectorBorder = selectorTileBoxDecoration.border as Border;
+
+      expect(
+        selectorBorder.top.width,
+        equals(unselectedBorderWidth),
+      );
+      expect(
+        selectorBorder.bottom.width,
+        equals(unselectedBorderWidth),
+      );
+      expect(
+        selectorBorder.left.width,
+        equals(unselectedBorderWidth),
+      );
+      expect(
+        selectorBorder.right.width,
+        equals(unselectedBorderWidth),
+      );
+    },
+  );
+
+  testWidgets(
+    'GIVEN an SelectorTile widget '
+    'WHEN isSelected is true '
+    'THEN border width is 1',
+    (WidgetTester tester) async {
+      const selectedBorderWidth = 1.0;
+
+      await tester.pumpWidgetWithMaterialApp(
+        selectorTileWidget(
+          isSelected: true,
+        ),
+      );
+
+      final findSelectorTile = find.byKey(selectorTileKey);
+      final findSelectorTileDescendants = find.descendant(
+          of: findSelectorTile, matching: find.byType(Container));
+
+      final selectorTileContainer =
+          findSelectorTileDescendants.evaluate().first.widget as Container;
+      final selectorTileBoxDecoration =
+          selectorTileContainer.foregroundDecoration as BoxDecoration;
+      final selectorBorder = selectorTileBoxDecoration.border as Border;
+
+      expect(
+        selectorBorder.top.width,
+        equals(selectedBorderWidth),
+      );
+      expect(
+        selectorBorder.bottom.width,
+        equals(selectedBorderWidth),
+      );
+      expect(
+        selectorBorder.left.width,
+        equals(selectedBorderWidth),
+      );
+      expect(
+        selectorBorder.right.width,
+        equals(selectedBorderWidth),
+      );
+    },
+  );
+
+  testWidgets(
+    'GIVEN an SelectorTile widget '
+    'WHEN isSelected is true '
+    'THEN border color is blue5 in light mode',
+    (WidgetTester tester) async {
+      const selectedBorderColorLight = blue5;
+
+      await tester.pumpWidgetWithMaterialApp(
+        Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                colorScheme: customColorScheme,
+              ),
+              child: selectorTileWidget(
+                isSelected: true,
+              ),
+            );
+          },
+        ),
+      );
+
+      final findSelectorTile = find.byKey(selectorTileKey);
+      final findSelectorTileDescendants = find.descendant(
+        of: findSelectorTile,
+        matching: find.byType(Container),
+      );
+
+      final selectorTileContainer =
+          findSelectorTileDescendants.evaluate().first.widget as Container;
+      final selectorTileBoxDecoration =
+          selectorTileContainer.foregroundDecoration as BoxDecoration;
+      final selectorBorder = selectorTileBoxDecoration.border as Border;
+
+      expect(
+        selectorBorder.top.color,
+        equals(selectedBorderColorLight),
+      );
+      expect(
+        selectorBorder.bottom.color,
+        equals(selectedBorderColorLight),
+      );
+      expect(
+        selectorBorder.right.color,
+        equals(selectedBorderColorLight),
+      );
+      expect(
+        selectorBorder.left.color,
+        equals(selectedBorderColorLight),
+      );
+    },
+  );
+
+  testWidgets(
+    'GIVEN an SelectorTile widget '
+    'WHEN isSelected is true '
+    'THEN border color is darkBlue6 in dark mode',
+    (WidgetTester tester) async {
+      const selectedBorderColorDark = darkBlue6;
+
+      await tester.pumpWidgetWithMaterialApp(
+        Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                colorScheme: darkCustomColorScheme,
+              ),
+              child: selectorTileWidget(
+                isSelected: true,
+              ),
+            );
+          },
+        ),
+      );
+
+      final findSelectorTile = find.byKey(selectorTileKey);
+      final findSelectorTileDescendants = find.descendant(
+        of: findSelectorTile,
+        matching: find.byType(Container),
+      );
+
+      final selectorTileContainer =
+          findSelectorTileDescendants.evaluate().first.widget as Container;
+      final selectorTileBoxDecoration =
+          selectorTileContainer.foregroundDecoration as BoxDecoration;
+      final selectorBorder = selectorTileBoxDecoration.border as Border;
+
+      expect(
+        selectorBorder.top.color,
+        equals(selectedBorderColorDark),
+      );
+      expect(
+        selectorBorder.bottom.color,
+        equals(selectedBorderColorDark),
+      );
+      expect(
+        selectorBorder.right.color,
+        equals(selectedBorderColorDark),
+      );
+      expect(
+        selectorBorder.left.color,
+        equals(selectedBorderColorDark),
+      );
+    },
+  );
+
+  testWidgets(
+    'GIVEN an SelectorTile widget '
+    'WHEN isSelected is false '
+    'THEN border color is grey2 in light mode',
+    (WidgetTester tester) async {
+      const unselectedBorderColorLight = grey2;
+
+      await tester.pumpWidgetWithMaterialApp(
+        Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                colorScheme: customColorScheme,
+              ),
+              child: selectorTileWidget(),
+            );
+          },
+        ),
+      );
+
+      final findSelectorTile = find.byKey(selectorTileKey);
+      final findSelectorTileDescendants = find.descendant(
+        of: findSelectorTile,
+        matching: find.byType(Container),
+      );
+
+      final selectorTileContainer =
+          findSelectorTileDescendants.evaluate().first.widget as Container;
+      final selectorTileBoxDecoration =
+          selectorTileContainer.foregroundDecoration as BoxDecoration;
+      final selectorBorder = selectorTileBoxDecoration.border as Border;
+
+      expect(
+        selectorBorder.top.color,
+        equals(unselectedBorderColorLight),
+      );
+      expect(
+        selectorBorder.bottom.color,
+        equals(unselectedBorderColorLight),
+      );
+      expect(
+        selectorBorder.right.color,
+        equals(unselectedBorderColorLight),
+      );
+      expect(
+        selectorBorder.left.color,
+        equals(unselectedBorderColorLight),
+      );
+    },
+  );
+
+    testWidgets(
+    'GIVEN an SelectorTile widget '
+    'WHEN isSelected is false '
+    'THEN border color is grey2 in dark mode',
+    (WidgetTester tester) async {
+      const unselectedBorderColorLight = grey2;
+
+      await tester.pumpWidgetWithMaterialApp(
+        Builder(
+          builder: (context) {
+            return Theme(
+              data: Theme.of(context).copyWith(
+                colorScheme: darkCustomColorScheme,
+              ),
+              child: selectorTileWidget(),
+            );
+          },
+        ),
+      );
+
+      final findSelectorTile = find.byKey(selectorTileKey);
+      final findSelectorTileDescendants = find.descendant(
+        of: findSelectorTile,
+        matching: find.byType(Container),
+      );
+
+      final selectorTileContainer =
+          findSelectorTileDescendants.evaluate().first.widget as Container;
+      final selectorTileBoxDecoration =
+          selectorTileContainer.foregroundDecoration as BoxDecoration;
+      final selectorBorder = selectorTileBoxDecoration.border as Border;
+
+      expect(
+        selectorBorder.top.color,
+        equals(unselectedBorderColorLight),
+      );
+      expect(
+        selectorBorder.bottom.color,
+        equals(unselectedBorderColorLight),
+      );
+      expect(
+        selectorBorder.right.color,
+        equals(unselectedBorderColorLight),
+      );
+      expect(
+        selectorBorder.left.color,
+        equals(unselectedBorderColorLight),
+      );
+    },
+  );
+}


### PR DESCRIPTION
## 🎯 Description

This PR reworks the currency selector that can be found in _Settings_ -> _General Settings_.
The old currency selector had some issues with the colors of the` ListTile`s and, taking in consideration the discussion that is happening in #333 about adding the system theme as option, I went with the updated design.

Design follows [this](https://www.figma.com/design/6NyY9yqunpbU7HIkbNEAL3/Sossoldi-App?node-id=3286-9189&t=5wYGZcAdXnVsZBaa-11) Figma frame.

Diving a bit deeper in the changes:

- Added `onSurfaceVariant` to `customColorScheme` and `darkCustomColorScheme` to have a lighter color that gives enough contrast when used on `surface` (`darkBlue6`). Please check these messages ([[1]](https://github.com/RIP-Comm/sossoldi/issues/356#issuecomment-2743009560), [[2]](https://github.com/RIP-Comm/sossoldi/issues/356#issuecomment-2743037750)) for more details on this addition.

- In `lib\pages\general_options\widgets` I've added the `selector` folder. It contains two files, `selector_container.dart` and `selector_tile.dart`:
  - `SelectorContainer` is a simple `Widget` responsible for the background and the top label. It takes a `label` and a `child`.
  - `SelectorTile` is the list tile like UI element which shows the currencies list (and ideally should also be used to show the appearance options).  
   I've tried to make it flexible while still maintaining the convenience of use. The important part for me here was to have a widget that can give a uniform look to the settings page and that can be reused when more settings will be added to the page. I know it will need to be updated as requirements will change but I can take care of that when time comes.  
   It has a customisable `title`, `trailing` (_String_) and `trailingWidget`. This widget is meant to handle selection between a number of options, for this purpose the `isSelected` _bool_ can be used. Also added a _void_ `onTap`.
- The old `CurrencySelectorDialog` has been renamed to `SettingsCurrencySelector` and it uses `SelectorContainer` and `SelectorTile` while maintaining the same currency selection state handling that was used in the previous implementation.
- `SettingsCurrencySelector` is then used in `lib\pages\general_options\general_settings.dart`.
- For what concern testing:  
  - Added some simple tests for the `SelectorTile` basic interactions.
  - Added a convenience `extension` on `WidgetTester` in `test\test_utils`. It's called `pumpWidgetWithMaterialApp` and as the name suggests, it's just a wrapper on `pumpWidget` which includes a `MaterialApp` and the `Material` widget. I've added an option to toggle on or off the `ProviderScope` as well (defaults to on).
  

Closes: #356   

## 📱 Changes

- [X] Describe key changes made
- [X] List any new features, bug fixes, or refactors
- [X] Include additional details if necessary

## 🧪 Testing Instructions

### Behaviour
1. Go to _Settings_ -> _General Settings_
2. Change your selected currency


## 📸 Screenshots / Screen Recordings (if applicable)

| Before | After |
|----------|----------|
|https://github.com/user-attachments/assets/e949b3cc-c240-46d1-a46f-5a9b345f1f3d | https://github.com/user-attachments/assets/b4ac15cb-11c7-43df-9047-16cc669f5645 |


## 🔍 Checklist for reviewers
- [X] Code is formatted correctly
- [X] Tests are passing
- [X] New tests are added (if needed)
- [X] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [X] Android


## ✍️ Additional Context

Note that this new UI might look a bit out of place because the appearance switcher is still the same. Hopefully when both components use this new layout it'll look better as a whole 😅 
