### PR TITLE
Fix potential crash in `/add-page` route handling

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -32,7 +32,12 @@ Route<dynamic> makeRoute(RouteSettings settings) {
     case '/dashboard':
       return _materialPageRoute(settings.name, const HomePage());
     case '/add-page':
-      final args = settings.arguments as Map<String, dynamic>?;
+      Map<String, bool>? args;
+      try {
+        args = settings.arguments as Map<String, bool>?;
+      } catch (_) {
+        args = null;
+      }
       return _materialPageRoute(
         settings.name,
         AddPage(recurrencyEditingPermitted: args?['recurrencyEditingPermitted'] ?? true),


### PR DESCRIPTION
## 🎯 Description

This pull request includes a change to the `makeRoute` method in `lib/routes.dart` to improve the handling of route arguments. The most important change involves updating the type of `args` and adding error handling to ensure the application does not crash if the arguments are of an unexpected type.

Improvements to error handling:

* [`lib/routes.dart`](diffhunk://#diff-db86e4d234b8ce36f13aae12c233aec35d10552b4b295edf1a456ae87fb16bbbL35-R40): Updated the type of `args` to `Map<String, bool>?` and added a try-catch block to handle cases where the route arguments are not of the expected type.

Closes: #365   

## 📱 Changes

- [ ] Describe key changes made
- [ ] List any new features, bug fixes, or refactors
- [ ] Include additional details if necessary

## 🧪 Testing Instructions

### Behaviour
1. Do this
2. Do that


## 📸 Screenshots / Screen Recordings (if applicable)

If your PR involves UI changes, please add screenshots or screen recordings here.

| Platform | Before | After |
|----------|--------|-------|
| Android  |        |       |
| iOS      |        |       |


## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [ ] New tests are added (if needed)
- [x] Style matches the figma/designer requests
- Tested on:
    - [x] iOS
    - [x] Android


## ✍️ Additional Context

Add any other information that we might know 
