### PR TITLE
del(pubspec): remove gap as dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   flutter_native_splash: ^2.4.4
   flutter_phoenix: ^1.1.1
   flutter_riverpod: ^2.6.1
-  gap: ^3.0.1
   intl: ^0.19.0
   path: ^1.9.1
   path_provider: ^2.1.5


### PR DESCRIPTION
## 🎯 Description

Gap was not being used in the whole project and so it was an unnecessary dependency

Closes: #361

## 📱 Changes

Removed `gap` from `pubspec.yml`

## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [x] New tests are added (if needed)
- [x] Style matches the figma/designer requests
- Tested on:
    - [x] iOS
    - [ ] Android


## ✍️ Additional Context

Don't think that Android tests are needed here 😄
