### PR TITLE
fix: Resolve #381 - Use DecimalTextInputFormatter in TextFields

### DIFF
--- a/lib/pages/account_page/account_page.dart
+++ b/lib/pages/account_page/account_page.dart
@@ -123,7 +123,9 @@ class _AccountPage extends ConsumerState<AccountPage> with Functions {
                                     ),
                                   ),
                                 )),
-                            keyboardType: TextInputType.number,
+                            keyboardType: const TextInputType.numberWithOptions(
+                              decimal: true,
+                            ),
                             inputFormatters: <TextInputFormatter>[
                               DecimalTextInputFormatter(decimalDigits: 2),
                             ],

--- a/lib/pages/account_page/account_page.dart
+++ b/lib/pages/account_page/account_page.dart
@@ -10,6 +10,7 @@ import '../../providers/accounts_provider.dart';
 import '../../model/transaction.dart';
 import '../../providers/currency_provider.dart';
 import '../../providers/transactions_provider.dart';
+import '../../utils/decimal_text_input_formatter.dart';
 import '../../utils/snack_bars/transactions_snack_bars.dart';
 
 class AccountPage extends ConsumerStatefulWidget {
@@ -124,9 +125,7 @@ class _AccountPage extends ConsumerState<AccountPage> with Functions {
                                 )),
                             keyboardType: TextInputType.number,
                             inputFormatters: <TextInputFormatter>[
-                              FilteringTextInputFormatter.allow(
-                                RegExp(r'^\d*\.?\d{0,2}'),
-                              ),
+                              DecimalTextInputFormatter(decimalDigits: 2),
                             ],
                           ),
                           const SizedBox(height: 16),
@@ -150,8 +149,9 @@ class _AccountPage extends ConsumerState<AccountPage> with Functions {
                                               newBalance: currencyToNum(
                                                   _newBalanceController.text),
                                               account: account);
-                                      if (context.mounted)
+                                      if (context.mounted) {
                                         Navigator.of(context).pop();
+                                      }
                                     }
                                   },
                                   label: const Text("Save"),

--- a/lib/pages/accounts/add_account.dart
+++ b/lib/pages/accounts/add_account.dart
@@ -1,12 +1,11 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../providers/accounts_provider.dart';
 import '../../constants/constants.dart';
 import '../../constants/functions.dart';
 import '../../constants/style.dart';
 import '../../providers/currency_provider.dart';
+import '../../utils/decimal_text_input_formatter.dart';
 import 'widgets/confirm_account_deletion_dialog.dart';
 
 class AddAccount extends ConsumerStatefulWidget {
@@ -293,10 +292,8 @@ class _AddAccountState extends ConsumerState<AddAccount> with Functions {
                           ),
                           keyboardType:
                               TextInputType.numberWithOptions(decimal: true),
-                          inputFormatters: <TextInputFormatter>[
-                            FilteringTextInputFormatter.allow(
-                              RegExp(r'^\d*\.?\d{0,2}'),
-                            ),
+                          inputFormatters: [
+                            DecimalTextInputFormatter(decimalDigits: 2),
                           ],
                           style: Theme.of(context).textTheme.titleLarge,
                         ),

--- a/lib/pages/add_page/widgets/amount_widget.dart
+++ b/lib/pages/add_page/widgets/amount_widget.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import "package:flutter_riverpod/flutter_riverpod.dart";
@@ -45,7 +47,7 @@ class _AmountWidgetState extends ConsumerState<AmountWidget> with Functions {
         keyboardType: TextInputType.numberWithOptions(
           decimal: true,
           // Leaving the default behaviour on Android which seems to be working as expeceted.
-          signed: defaultTargetPlatform == TargetPlatform.android,
+          signed: Platform.isAndroid,
         ),
         inputFormatters: [
           DecimalTextInputFormatter(decimalDigits: 2),

--- a/lib/pages/add_page/widgets/amount_widget.dart
+++ b/lib/pages/add_page/widgets/amount_widget.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import "package:flutter_riverpod/flutter_riverpod.dart";
 

--- a/lib/pages/add_page/widgets/amount_widget.dart
+++ b/lib/pages/add_page/widgets/amount_widget.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import '../../../constants/functions.dart';
 import "../../../constants/style.dart";
 import '../../../providers/currency_provider.dart';
 import '../../../providers/transactions_provider.dart';
+import '../../../utils/decimal_text_input_formatter.dart';
 
 class AmountWidget extends ConsumerStatefulWidget {
   const AmountWidget(
@@ -48,22 +48,7 @@ class _AmountWidgetState extends ConsumerState<AmountWidget> with Functions {
           signed: defaultTargetPlatform == TargetPlatform.android,
         ),
         inputFormatters: [
-          // Allow only digits and one decimal separator.
-          FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
-
-          // AI generated regex: checks that the String contains either one comma or
-          // one period. Only two decimal digits only allowed.
-          //
-          // Because replacementString is not nullable and defaults to empty String
-          // I've set it to the current input text so that every time a second period
-          // is inserted, it won't clear the text that's already present.
-          FilteringTextInputFormatter.allow(
-            RegExp(r'^(\d*([.,]\d{0,2})?|[.,]\d{0,2})$'),
-            replacementString: widget.amountController.text,
-          ),
-
-          // Replaces comma with period.
-          FilteringTextInputFormatter.deny(RegExp(r','), replacementString: '.'),
+          DecimalTextInputFormatter(decimalDigits: 2),
         ],
         autofocus: false,
         textAlign: TextAlign.center,

--- a/lib/pages/onboarding_page/widgets/account_setup.dart
+++ b/lib/pages/onboarding_page/widgets/account_setup.dart
@@ -1,10 +1,10 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../constants/constants.dart';
 import '../../../providers/accounts_provider.dart';
+import '../../../utils/decimal_text_input_formatter.dart';
 import '/constants/style.dart';
 
 class AccountSetup extends ConsumerStatefulWidget {
@@ -160,8 +160,7 @@ class _AccountSetupState extends ConsumerState<AccountSetup> {
                               decimal: true, signed: true),
                           onChanged: validateAmount,
                           inputFormatters: [
-                            FilteringTextInputFormatter.allow(
-                                RegExp(r'^\d*\.?\d{0,2}')),
+                            DecimalTextInputFormatter(decimalDigits: 2),
                           ],
                           decoration: InputDecoration(
                             hintText: "e.g 1300 €",

--- a/lib/pages/onboarding_page/widgets/account_setup.dart
+++ b/lib/pages/onboarding_page/widgets/account_setup.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -30,7 +32,8 @@ class _AccountSetupState extends ConsumerState<AccountSetup> {
   }
 
   Future<void> _flagOnBoardingCompleted() async {
-    final SharedPreferences sharedPreferences = await SharedPreferences.getInstance();
+    final SharedPreferences sharedPreferences =
+        await SharedPreferences.getInstance();
     sharedPreferences.setBool('onboarding_completed', true);
   }
 
@@ -156,8 +159,10 @@ class _AccountSetupState extends ConsumerState<AccountSetup> {
                         TextField(
                           textAlign: TextAlign.center,
                           controller: amountController,
-                          keyboardType: const TextInputType.numberWithOptions(
-                              decimal: true, signed: true),
+                          keyboardType: TextInputType.numberWithOptions(
+                            decimal: true,
+                            signed: Platform.isAndroid,
+                          ),
                           onChanged: validateAmount,
                           inputFormatters: [
                             DecimalTextInputFormatter(decimalDigits: 2),

--- a/lib/pages/planning_page/widget/budget_category_selector.dart
+++ b/lib/pages/planning_page/widget/budget_category_selector.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../constants/constants.dart';
 import '../../../model/budget.dart';
 import '../../../model/category_transaction.dart';
+import '../../../utils/decimal_text_input_formatter.dart';
 
 class BudgetCategorySelector extends ConsumerStatefulWidget {
   final List<CategoryTransaction> categories;
@@ -114,8 +115,11 @@ class _BudgetCategorySelector extends ConsumerState<BudgetCategorySelector> {
               padding: const EdgeInsets.all(8),
               child: TextField(
                 controller: _controller,
-                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
-                keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                inputFormatters: [
+                  DecimalTextInputFormatter(decimalDigits: 2),
+                ],
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
                 onChanged: (_) {
                   setState(() {
                     _modifyBudget();


### PR DESCRIPTION
## 🎯 Description

The aim of this PR is to standardize the way numerical input fields are formatted.
I did a similar change a couple of weeks ago on the `lib\pages\add_page\widgets\amount_widget.dart` and I thought I could replicate this on every `TextField` widget where the `inputFormatters` property is used.

While doing this change I realized there is an **unused** custom input formatter in `lib\utils\decimal_text_input_formatter.dart` which does everything we need (introduced in the codebase more than 1 year ago).

Please let me know if this was not used for a specific reason. The test I wrote for my previous PR are still passing so I'm assuming everything is working as expected.

I haven't tested specifically on iOS but the logic that replaces the comma (which is present in the iOS numpad) with the period it's there.

I've also updated the `keyboardType` property where needed, to show the numpad with the comma on iOS.

Closes: #381 (issue)  

## 📱 Changes

- [X] Describe key changes made
- [X] List any new features, bug fixes, or refactors
- [X] Include additional details if necessary

## 🧪 Testing Instructions

All of the `TextField`s that are used to input an amount should allow both commas and periods to be inserted (commas will be converted in periods) and should allow up to 2 decimal digits.

## 📸 Screenshots / Screen Recordings (if applicable)

No screenshots or recordings


## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [x] New tests are added (if needed)
- [x] Style matches the figma/designer requests
- Tested on:
    - [x] iOS
    - [x] Android


## ✍️ Additional Context

Add any other information that we might know 
