### PR TITLE
fix: Resolve #383 - Allow null on RecurringPaymentCard

### DIFF
--- a/lib/pages/planning_page/widget/recurring_payment_card.dart
+++ b/lib/pages/planning_page/widget/recurring_payment_card.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../constants/constants.dart';
@@ -41,7 +42,7 @@ class RecurringPaymentCard extends ConsumerWidget with Functions {
     final currencyState = ref.watch(currencyStateNotifier);
 
     var cat = categories
-        ?.firstWhere((element) => element.id == transaction.idCategory);
+        ?.firstWhereOrNull((element) => element.id == transaction.idCategory);
 
     return cat != null
         ? Container(


### PR DESCRIPTION
## 🎯 Description

I'm not 100% of what it is specifically that causes this issue but it can be observed when deleting the DB using the developer options. 

Once the DB is cleared the app will throw: `Bad state: No element` because `firstWhere()` is not finding any match.
The build method actually handles the case where `cat` is `null` so I just replaced `firstWhere()` with `firstWhereOrNull()`.

Closes: #383 (issue)  

## 📱 Changes

- [X] Describe key changes made
- [X] List any new features, bug fixes, or refactors
- [X] Include additional details if necessary

## 🧪 Testing Instructions

### Behaviour

   1.  Generate demo data in Settings page
   2. Check that the Planning page has data
   3. Go back to Settings page and clear DB data



## 📸 Screenshots / Screen Recordings (if applicable)

No screenshots or recordings.


## 🔍 Checklist for reviewers
- [ ] Code is formatted correctly
- [ ] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [ ] Android


## ✍️ Additional Context

Add any other information that we might know 
