### PR TITLE
perf(add_category): autoselect category type based on transaction type

### DIFF
--- a/lib/pages/categories/add_category.dart
+++ b/lib/pages/categories/add_category.dart
@@ -29,12 +29,10 @@ class _AddCategoryState extends ConsumerState<AddCategory> {
   void initState() {
     super.initState();
 
-    // Set default category type based on transaction type
     final transactionType = ref.read(transactionTypeProvider);
     categoryType = ref.read(transactionToCategoryProvider(transactionType))
         ?? CategoryTransactionType.expense;
 
-    // If editing an existing category, override values
     final selectedCategory = ref.read(selectedCategoryProvider);
     if (selectedCategory != null) {
       nameController.text = selectedCategory.name;

--- a/lib/pages/categories/add_category.dart
+++ b/lib/pages/categories/add_category.dart
@@ -4,6 +4,7 @@ import '../../constants/constants.dart';
 import '../../constants/style.dart';
 import '../../model/category_transaction.dart';
 import '../../providers/categories_provider.dart';
+import '../../providers/transactions_provider.dart';
 import '../../ui/device.dart';
 import '../../ui/extensions.dart';
 
@@ -18,7 +19,7 @@ class AddCategory extends ConsumerStatefulWidget {
 
 class _AddCategoryState extends ConsumerState<AddCategory> {
   final TextEditingController nameController = TextEditingController();
-  CategoryTransactionType categoryType = CategoryTransactionType.income;
+  late CategoryTransactionType categoryType;
   String categoryIcon = iconList.keys.first;
   int categoryColor = 0;
 
@@ -26,9 +27,14 @@ class _AddCategoryState extends ConsumerState<AddCategory> {
 
   @override
   void initState() {
-    if (widget.hideIncome) {
-      categoryType = CategoryTransactionType.expense;
-    }
+    super.initState();
+
+    // Set default category type based on transaction type
+    final transactionType = ref.read(transactionTypeProvider);
+    categoryType = ref.read(transactionToCategoryProvider(transactionType))
+        ?? CategoryTransactionType.expense;
+
+    // If editing an existing category, override values
     final selectedCategory = ref.read(selectedCategoryProvider);
     if (selectedCategory != null) {
       nameController.text = selectedCategory.name;
@@ -36,7 +42,6 @@ class _AddCategoryState extends ConsumerState<AddCategory> {
       categoryIcon = selectedCategory.symbol;
       categoryColor = selectedCategory.color;
     }
-    super.initState();
   }
 
   @override

--- a/lib/pages/categories/add_category.dart
+++ b/lib/pages/categories/add_category.dart
@@ -30,8 +30,8 @@ class _AddCategoryState extends ConsumerState<AddCategory> {
     super.initState();
 
     final transactionType = ref.read(transactionTypeProvider);
-    categoryType = ref.read(transactionToCategoryProvider(transactionType))
-        ?? CategoryTransactionType.expense;
+    categoryType = ref.read(transactionToCategoryProvider(transactionType)) ??
+        CategoryTransactionType.expense;
 
     final selectedCategory = ref.read(selectedCategoryProvider);
     if (selectedCategory != null) {


### PR DESCRIPTION
## 🎯 Description  

When creating a new category, the category type dropdown is preselected based on the transaction type (income or expense).  

Closes: #390  

## 📱 Changes  

- [x] Import the transaction provider in `add_category`  
- [x] Read the transaction type using the transaction provider and use it to set the category type  
- [x] Set the default category type to **'expense'** if the transaction provider returns `null`  
- [x] Remove redundant "hide income" logic for selecting only the **'expense'** category type in the initial setup (it is already handled during the dropdown load)  


## 🧪 Testing Instructions  

### Expected Behavior  

#### **TEST 1 - Ensure correct default selection**  
1. Add a new category from the **Add Transaction** screen with **'income'** selected as the transaction type.  
2. The category type dropdown should default to **'income'**.  
3. Repeat steps 1 and 2 with **'expense'**, and the dropdown should default to **'expense'**.  

#### **TEST 2 - Remember the selected transaction type**  
1. Open **Add Transaction** and select **'income'** as the transaction type.  
2. Go to **Settings → Categories → + (Add Category)**. The category type dropdown should default to **'income'**.  
3. Repeat steps 1 and 2 with **'expense'**, and the dropdown should default to **'expense'**.  

#### **TEST 3 - No side effects for 'transfer' transaction type**  
1. Open **Add Transaction** and select **'transfer'** as the transaction type.  
2. Go to **Settings → Categories → + (Add Category)**. The category type dropdown should default to **'expense'**.  

#### **TEST 4 - No side effects on the initial setup**  
1. Set up the app for the first time.  
2. When creating the first category, the only available option should be **'expense'**.  

## 📸 Screen Recordings

### **Test Recordings: Creating a New Category**  

<details>  
  <summary>In initial setup</summary>  

   https://github.com/user-attachments/assets/83e7a4c0-b155-48e6-80cc-eea13bc0d6f9  

</details>  

<details>  
  <summary>From 'Expense' transaction</summary>  

   https://github.com/user-attachments/assets/8d8e3277-6fdf-47ff-8a1f-ae03a3cd6e04  

</details>  

<details>  
  <summary>From 'Income' transaction</summary>  

   https://github.com/user-attachments/assets/af635c06-3210-4187-b541-b08021a98495  

</details>  

<details>  
  <summary>From Categories (without conflicts)</summary>  

   https://github.com/user-attachments/assets/5c988ca0-1f6c-495e-b811-acc3af05beed  

</details>  

## 🔍 Checklist for Reviewers  

- [x] Code is properly formatted  
- [x] Tests are passing  
- [ ] New tests added (if necessary)  
- [ ] Style follows the Figma/designer's guidelines  
- Tested on:  
  - [ ] iOS  
  - [x] Android  

## ✍️ Additional Context  

None.  
