### PR TITLE
Remove unused code that created the 'sossoldi_exports' directory

### DIFF
--- a/lib/database/sossoldi_database.dart
+++ b/lib/database/sossoldi_database.dart
@@ -58,12 +58,6 @@ class SossoldiDatabase {
 
   Future<String> exportToCSV() async {
     final db = await database;
-    final Directory documentsDir = await getApplicationDocumentsDirectory();
-    final String csvDir = join(documentsDir.path, 'sossoldi_exports');
-
-    // Create exports directory if it doesn't exist
-    await Directory(csvDir).create(recursive: true);
-
     // Get all table names
     final List<Map<String, dynamic>> tables = await db.rawQuery(
         "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'android_%'");


### PR DESCRIPTION
## 🎯 Description

Removes unused code that creates the  `'sossoldi_exports'` directory during CSV generation. 

The `exportToCSV()` method generates and returns the CSV string, but does not use the created folder.

## 📱 Changes

Removed leftover directory creation code from `exportToCSV()` method.

## 🧪 Testing Instructions

Export CSV, as-is.

## 📸 Screenshots / Screen Recordings (if applicable)

N/A


## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- Tested on:
    - [ ] iOS
    - [x] Android


## ✍️ Additional Context

N/A
