### PR TITLE
feat(ui): auto-close category panel on selection for improved UX

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref != '' && github.head_ref || github.ref  }}
   cancel-in-progress: true
 
 jobs:

--- a/lib/pages/add_page/widgets/category_selector.dart
+++ b/lib/pages/add_page/widgets/category_selector.dart
@@ -22,6 +22,11 @@ class CategorySelector extends ConsumerStatefulWidget {
 }
 
 class _CategorySelectorState extends ConsumerState<CategorySelector> {
+  void _selectCategory(BuildContext context, CategoryTransaction category) {
+    ref.read(categoryProvider.notifier).state = category;
+    Navigator.pop(context);
+  }
+
   @override
   Widget build(BuildContext context) {
     final transactionType = ref.watch(transactionTypeProvider);
@@ -72,11 +77,7 @@ class _CategorySelectorState extends ConsumerState<CategorySelector> {
                         itemBuilder: (context, i) {
                           CategoryTransaction category = categories[i];
                           return GestureDetector(
-                            onTap: () => {
-                              ref.read(categoryProvider.notifier).state =
-                                  category,
-                              Navigator.of(context).pop(),
-                            },
+                            onTap: () => _selectCategory(context, category),
                             child: Padding(
                               padding: const EdgeInsets.symmetric(
                                   horizontal: Sizes.lg),
@@ -132,9 +133,7 @@ class _CategorySelectorState extends ConsumerState<CategorySelector> {
                         itemBuilder: (context, i) {
                           CategoryTransaction category = categories[i];
                           return ListTile(
-                            onTap: () => ref
-                                .read(categoryProvider.notifier)
-                                .state = category,
+                            onTap: () => _selectCategory(context, category),
                             leading: RoundedIcon(
                               icon: iconList[category.symbol],
                               backgroundColor:


### PR DESCRIPTION
## 🎯 Description

This pull request updates the category selection behavior by automatically closing the category panel after a user selects a category.
Currently, after selecting a category, the panel remains open, requiring the user to manually close it. This extra step interrupts the navigation flow and creates friction in the user experience.

Closes: #354  

## 📱 Changes

- [x] Describe key changes made
- [x] List any new features, bug fixes, or refactors
- [x] Include additional details if necessary

## 🧪 Testing Instructions

### Behaviour
1. Add a new transaction.
2. Click on a category from the "All categories" list.
3. The panel will now automatically close upon selecting a category.


## 🔍 Checklist for reviewers
- [ ] Code is formatted correctly
- [ ] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [ ] Android


## ✍️ Additional Context

Add any other information that we might know 
