### PR TITLE
fix: handle negative values correctly in DecimalTextInputFormatter

### DIFF
--- a/lib/utils/decimal_text_input_formatter.dart
+++ b/lib/utils/decimal_text_input_formatter.dart
@@ -18,7 +18,11 @@ class DecimalTextInputFormatter extends TextInputFormatter {
     String value = newValue.text;
 
     RegExp regex = RegExp(r'[\d\,\.]');
-
+    
+    if (value=="-") {
+      value="";
+    }
+    
     if (value.isNotEmpty && !regex.hasMatch(value[value.length - 1])) {
       return oldValue;
     }

--- a/lib/utils/decimal_text_input_formatter.dart
+++ b/lib/utils/decimal_text_input_formatter.dart
@@ -18,11 +18,11 @@ class DecimalTextInputFormatter extends TextInputFormatter {
     String value = newValue.text;
 
     RegExp regex = RegExp(r'[\d\,\.]');
-    
-    if (value=="-") {
-      value="";
+
+    if (value == "-") {
+      value = "";
     }
-    
+
     if (value.isNotEmpty && !regex.hasMatch(value[value.length - 1])) {
       return oldValue;
     }


### PR DESCRIPTION
## 🎯 Description

Negative values were not handled correctly by the DecimalTextInputFormatter.

Closes: #416 

## 📱 Changes

- [ ] Describe key changes made
- [ ] List any new features, bug fixes, or refactors
- [ ] Include additional details if necessary

## 🧪 Testing Instructions

### Behaviour
1. Do this
2. Do that


## 📸 Screenshots / Screen Recordings (if applicable)

If your PR involves UI changes, please add screenshots or screen recordings here.

| Platform | Before | After |
|----------|--------|-------|
| Android  |        |       |
| iOS      |        |       |


## 🔍 Checklist for reviewers
- [ ] Code is formatted correctly
- [ ] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [ ] Android


## ✍️ Additional Context

Add any other information that we might know 
