### PR TITLE
fix: correctly show expense amounts in list tiles

### DIFF
--- a/lib/pages/transactions_page/widgets/account_list_tile.dart
+++ b/lib/pages/transactions_page/widgets/account_list_tile.dart
@@ -146,6 +146,10 @@ class TransactionRow extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final currencyState = ref.watch(currencyStateNotifier);
+    final amount = transaction.type == TransactionType.income
+        ? transaction.amount
+        : -transaction.amount;
+
     return Container(
       padding: const EdgeInsets.symmetric(
         horizontal: Sizes.sm,
@@ -166,9 +170,11 @@ class TransactionRow extends ConsumerWidget {
                       style: Theme.of(context).textTheme.titleMedium,
                     ),
                     Text(
-                      "${transaction.amount.toCurrency()} ${currencyState.selectedCurrency.symbol}",
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: (transaction.amount > 0) ? green : red),
+                      "${amount.toCurrency()} ${currencyState.selectedCurrency.symbol}",
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyLarge
+                          ?.copyWith(color: (amount > 0) ? green : red),
                     ),
                   ],
                 ),

--- a/lib/pages/transactions_page/widgets/category_list_tile.dart
+++ b/lib/pages/transactions_page/widgets/category_list_tile.dart
@@ -142,6 +142,9 @@ class TransactionRow extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final amount = transaction.type == TransactionType.income
+        ? transaction.amount
+        : -transaction.amount;
     final currencyState = ref.watch(currencyStateNotifier);
     return Container(
       padding: const EdgeInsets.symmetric(
@@ -163,9 +166,11 @@ class TransactionRow extends ConsumerWidget {
                       style: Theme.of(context).textTheme.titleMedium,
                     ),
                     Text(
-                      "${transaction.amount.toCurrency()} ${currencyState.selectedCurrency.symbol}",
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                          color: (transaction.amount > 0) ? green : red),
+                      "${amount.toCurrency()} ${currencyState.selectedCurrency.symbol}",
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyLarge
+                          ?.copyWith(color: (amount > 0) ? green : red),
                     ),
                   ],
                 ),


### PR DESCRIPTION
## 🎯 Description

Expense values were not displayed correctly when grouping transactions by category or by account.

Closes: #427 
## 📱 Changes

- [ ] Describe key changes made
- [ ] List any new features, bug fixes, or refactors
- [ ] Include additional details if necessary

## 🧪 Testing Instructions

### Behaviour
1. Do this
2. Do that


## 📸 Screenshots / Screen Recordings (if applicable)
Here's the new behaviour:
![433777674-b63ef993-2efe-45f1-9369-21b91c9a17ca](https://github.com/user-attachments/assets/785b4034-0d93-47f2-979a-cb793bf98a4e)

This also matches the [figma design](https://www.figma.com/design/6NyY9yqunpbU7HIkbNEAL3/Sossoldi-App?node-id=1529-4389&t=Q9wenCXn4W9EJJRF-0)
| Platform | Before | After |
|----------|--------|-------|
| Android  |        |       |
| iOS      |        |       |


## 🔍 Checklist for reviewers
- [ ] Code is formatted correctly
- [ ] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [ ] Android


## ✍️ Additional Context
Sorry I messed up with the old PR 
