### PR TITLE
fix: Transactions can have categories

### DIFF
--- a/lib/providers/transactions_provider.dart
+++ b/lib/providers/transactions_provider.dart
@@ -115,15 +115,19 @@ class AsyncTransactionsNotifier
       {BankAccount? account, DateTime? date, TransactionType? type}) async {
     state = const AsyncValue.loading();
 
+    final TransactionType t = type ?? ref.read(transactionTypeProvider);
+
     Transaction transaction = Transaction(
       date: date ?? ref.read(dateProvider),
       amount: amount,
-      type: type ?? ref.read(transactionTypeProvider),
+      type: t,
       note: label,
       idBankAccount: (account ?? ref.read(bankAccountProvider))!.id!,
       idBankAccountTransfer:
           account != null ? null : ref.read(bankAccountTransferProvider)?.id,
-      idCategory: account != null ? null : ref.read(categoryProvider)?.id,
+      idCategory: account != null || t == TransactionType.transfer
+          ? null
+          : ref.read(categoryProvider)?.id,
       recurring:
           account != null ? false : ref.read(selectedRecurringPayProvider),
     );

--- a/lib/ui/widgets/transactions_list.dart
+++ b/lib/ui/widgets/transactions_list.dart
@@ -166,7 +166,9 @@ class TransactionTile extends ConsumerWidget {
               ),
         ),
         subtitle: Text(
-          transaction.categoryName ?? "Uncategorized",
+          transaction.type == TransactionType.transfer
+              ? ""
+              : transaction.categoryName ?? "Uncategorized",
           overflow: TextOverflow.ellipsis,
           style: Theme.of(context).textTheme.labelMedium!.copyWith(
                 color: Theme.of(context).colorScheme.primary,


### PR DESCRIPTION
## 🎯 Description


Closes: #440 

## 📱 Changes

Transactions will not be assigned a category.

## 🧪 Testing Instructions

## 📸 Screenshots / Screen Recordings (if applicable)
![Immagine 2025-05-12 180338](https://github.com/user-attachments/assets/1ca9709a-ab66-4e99-9e63-ba90dec9c60a)


| Platform | Before | After |
|----------|--------|-------|
| Android  |        |       |
| iOS      |        |       |


## 🔍 Checklist for reviewers
- [ ] Code is formatted correctly
- [ ] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [ ] Android


## ✍️ Additional Context
I chose not to invalidate the category provider so that the user can still see the last selected category when switching back to an expense/income transaction.

These changes won't have any effect on the older transfers, and those displayed incorrectly will continue to appear in this manner.
