### PR TITLE
Feat: blur balance

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -86,8 +86,8 @@ class _HomePageState extends ConsumerState<HomePage> {
                                                     .primary),
                                       ),
                                       TextSpan(
-                                        text:
-                                            currencyState.selectedCurrency.symbol,
+                                        text: currencyState
+                                            .selectedCurrency.symbol,
                                         style: Theme.of(context)
                                             .textTheme
                                             .bodyLarge
@@ -122,8 +122,8 @@ class _HomePageState extends ConsumerState<HomePage> {
                                             ?.copyWith(color: green),
                                       ),
                                       TextSpan(
-                                        text:
-                                            currencyState.selectedCurrency.symbol,
+                                        text: currencyState
+                                            .selectedCurrency.symbol,
                                         style: Theme.of(context)
                                             .textTheme
                                             .labelLarge
@@ -155,8 +155,8 @@ class _HomePageState extends ConsumerState<HomePage> {
                                             ?.copyWith(color: red),
                                       ),
                                       TextSpan(
-                                        text:
-                                            currencyState.selectedCurrency.symbol,
+                                        text: currencyState
+                                            .selectedCurrency.symbol,
                                         style: Theme.of(context)
                                             .textTheme
                                             .labelLarge
@@ -321,13 +321,14 @@ class _HomePageState extends ConsumerState<HomePage> {
                   ),
                 ),
                 lastTransactions.when(
-                  data: (transactions) =>
-                      TransactionsList(transactions: transactions, blurAmounts: !isAmountVisible),
+                  data: (transactions) => TransactionsList(
+                      transactions: transactions,
+                      blurAmounts: !isAmountVisible),
                   loading: () => const SizedBox(),
                   error: (err, stack) => Text('Error: $err'),
                 ),
                 const SizedBox(height: Sizes.xxl),
-                const BudgetsSection(),
+                BudgetsSection(blurAmounts: !isAmountVisible),
               ],
             ),
           ),

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../ui/device.dart';
 import '../ui/extensions.dart';
+import '../ui/widgets/blur_widget.dart';
 import '../utils/snack_bars/transactions_snack_bars.dart';
 import 'home_widget/budgets_home.dart';
 import '../constants/style.dart';
@@ -16,6 +17,7 @@ import '../providers/currency_provider.dart';
 import '../providers/dashboard_provider.dart';
 import '../providers/theme_provider.dart';
 import '../providers/transactions_provider.dart';
+import 'structure.dart';
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -31,6 +33,7 @@ class _HomePageState extends ConsumerState<HomePage> {
     final lastTransactions = ref.watch(lastTransactionsProvider);
     final currencyState = ref.watch(currencyStateNotifier);
     final isDarkMode = ref.watch(appThemeStateNotifier).isDarkModeEnabled;
+    final isAmountVisible = ref.watch(visibilityAmountProvider);
 
     ref.listen(
         duplicatedTransactoinProvider,
@@ -68,31 +71,33 @@ class _HomePageState extends ConsumerState<HomePage> {
                                             .colorScheme
                                             .primary),
                               ),
-                              RichText(
-                                text: TextSpan(
-                                  children: [
-                                    TextSpan(
-                                      text: total.toCurrency(),
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .headlineLarge
-                                          ?.copyWith(
-                                              color: Theme.of(context)
-                                                  .colorScheme
-                                                  .primary),
-                                    ),
-                                    TextSpan(
-                                      text:
-                                          currencyState.selectedCurrency.symbol,
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .bodyLarge
-                                          ?.copyWith(
-                                              color: Theme.of(context)
-                                                  .colorScheme
-                                                  .primary),
-                                    ),
-                                  ],
+                              BlurWidget(
+                                child: RichText(
+                                  text: TextSpan(
+                                    children: [
+                                      TextSpan(
+                                        text: total.toCurrency(),
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .headlineLarge
+                                            ?.copyWith(
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .primary),
+                                      ),
+                                      TextSpan(
+                                        text:
+                                            currencyState.selectedCurrency.symbol,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodyLarge
+                                            ?.copyWith(
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .primary),
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               ),
                             ],
@@ -105,25 +110,27 @@ class _HomePageState extends ConsumerState<HomePage> {
                                 "INCOME",
                                 style: Theme.of(context).textTheme.labelMedium,
                               ),
-                              RichText(
-                                text: TextSpan(
-                                  children: [
-                                    TextSpan(
-                                      text: income.toCurrency(),
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .bodyMedium
-                                          ?.copyWith(color: green),
-                                    ),
-                                    TextSpan(
-                                      text:
-                                          currencyState.selectedCurrency.symbol,
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .labelLarge
-                                          ?.copyWith(color: green),
-                                    ),
-                                  ],
+                              BlurWidget(
+                                child: RichText(
+                                  text: TextSpan(
+                                    children: [
+                                      TextSpan(
+                                        text: income.toCurrency(),
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodyMedium
+                                            ?.copyWith(color: green),
+                                      ),
+                                      TextSpan(
+                                        text:
+                                            currencyState.selectedCurrency.symbol,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .labelLarge
+                                            ?.copyWith(color: green),
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               ),
                             ],
@@ -136,25 +143,27 @@ class _HomePageState extends ConsumerState<HomePage> {
                                 "EXPENSES",
                                 style: Theme.of(context).textTheme.labelMedium,
                               ),
-                              RichText(
-                                text: TextSpan(
-                                  children: [
-                                    TextSpan(
-                                      text: expense.toCurrency(),
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .bodyMedium
-                                          ?.copyWith(color: red),
-                                    ),
-                                    TextSpan(
-                                      text:
-                                          currencyState.selectedCurrency.symbol,
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .labelLarge
-                                          ?.copyWith(color: red),
-                                    ),
-                                  ],
+                              BlurWidget(
+                                child: RichText(
+                                  text: TextSpan(
+                                    children: [
+                                      TextSpan(
+                                        text: expense.toCurrency(),
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .bodyMedium
+                                            ?.copyWith(color: red),
+                                      ),
+                                      TextSpan(
+                                        text:
+                                            currencyState.selectedCurrency.symbol,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .labelLarge
+                                            ?.copyWith(color: red),
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               ),
                             ],
@@ -313,7 +322,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                 ),
                 lastTransactions.when(
                   data: (transactions) =>
-                      TransactionsList(transactions: transactions),
+                      TransactionsList(transactions: transactions, blurAmounts: !isAmountVisible),
                   loading: () => const SizedBox(),
                   error: (err, stack) => Text('Error: $err'),
                 ),

--- a/lib/pages/home_widget/budgets_home.dart
+++ b/lib/pages/home_widget/budgets_home.dart
@@ -8,7 +8,12 @@ import '../../providers/budgets_provider.dart';
 import '../../ui/device.dart';
 
 class BudgetsSection extends ConsumerWidget {
-  const BudgetsSection({super.key});
+  const BudgetsSection({
+    super.key,
+    this.blurAmounts = false,
+  });
+
+  final bool blurAmounts;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -82,6 +87,7 @@ class BudgetsSection extends ConsumerWidget {
                               padding: const EdgeInsets.symmetric(
                                   horizontal: Sizes.md),
                               child: BudgetCircularIndicator(
+                                blurAmounts: blurAmounts,
                                 title: budgets[index].name!,
                                 amount: budgets[index].amountLimit -
                                             budgets[index].spent >

--- a/lib/pages/structure.dart
+++ b/lib/pages/structure.dart
@@ -12,6 +12,9 @@ import 'transactions_page/transactions_page.dart';
 
 final StateProvider selectedIndexProvider = StateProvider<int>((ref) => 0);
 
+final StateProvider<bool> visibilityAmountProvider =
+    StateProvider<bool>((ref) => false);
+
 class Structure extends ConsumerStatefulWidget {
   const Structure({super.key});
 
@@ -39,15 +42,19 @@ class _StructureState extends ConsumerState<Structure> {
   @override
   Widget build(BuildContext context) {
     final selectedIndex = ref.watch(selectedIndexProvider);
+
+    final isVisible = ref.watch(visibilityAmountProvider);
+
     return Scaffold(
       // Prevent the fab moving up when the keyboard is opened
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
         backgroundColor:
             selectedIndex == 0 ? Theme.of(context).colorScheme.tertiary : null,
-        title: Text(
-          _pagesTitle.elementAt(selectedIndex),
-        ),
+        title: switch (selectedIndex) {
+          0 => null,
+          _ => Text(_pagesTitle.elementAt(selectedIndex)),
+        },
         leading: Padding(
           padding: const EdgeInsets.only(left: Sizes.lg),
           child: FilledButton(
@@ -57,13 +64,20 @@ class _StructureState extends ConsumerState<Structure> {
           ),
         ),
         actions: [
-          Padding(
-            padding: const EdgeInsets.all(Sizes.sm),
-            child: FilledButton(
-              onPressed: () => Navigator.of(context).pushNamed('/settings'),
-              style: FilledButton.styleFrom(shape: const CircleBorder()),
-              child: Icon(Icons.settings),
+          FilledButton(
+            onPressed: _onVisibilityTap,
+            style: FilledButton.styleFrom(shape: const CircleBorder()),
+            child: Icon(
+              switch (isVisible) {
+                true => Icons.visibility,
+                false => Icons.visibility_off,
+              },
             ),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pushNamed('/settings'),
+            style: FilledButton.styleFrom(shape: const CircleBorder()),
+            child: Icon(Icons.settings),
           ),
         ],
       ),
@@ -120,5 +134,10 @@ class _StructureState extends ConsumerState<Structure> {
       floatingActionButtonLocation:
           FloatingActionButtonLocation.miniCenterDocked,
     );
+  }
+
+  void _onVisibilityTap() {
+    ref.read(visibilityAmountProvider.notifier).state =
+        !ref.read(visibilityAmountProvider.notifier).state;
   }
 }

--- a/lib/pages/structure.dart
+++ b/lib/pages/structure.dart
@@ -13,7 +13,7 @@ import 'transactions_page/transactions_page.dart';
 final StateProvider selectedIndexProvider = StateProvider<int>((ref) => 0);
 
 final StateProvider<bool> visibilityAmountProvider =
-    StateProvider<bool>((ref) => false);
+    StateProvider<bool>((ref) => true);
 
 class Structure extends ConsumerStatefulWidget {
   const Structure({super.key});
@@ -138,6 +138,6 @@ class _StructureState extends ConsumerState<Structure> {
 
   void _onVisibilityTap() {
     ref.read(visibilityAmountProvider.notifier).state =
-        !ref.read(visibilityAmountProvider.notifier).state;
+        !ref.read(visibilityAmountProvider);
   }
 }

--- a/lib/ui/widgets/accounts_sum.dart
+++ b/lib/ui/widgets/accounts_sum.dart
@@ -8,6 +8,7 @@ import '../../providers/accounts_provider.dart';
 import '../../providers/currency_provider.dart';
 import '../device.dart';
 import '../extensions.dart';
+import 'blur_widget.dart';
 import 'rounded_icon.dart';
 
 /// This class shows account summaries in the dashboard
@@ -69,21 +70,23 @@ class AccountsSum extends ConsumerWidget {
                         account.name,
                         style: Theme.of(context).textTheme.bodyLarge,
                       ),
-                      RichText(
-                        text: TextSpan(
-                          children: [
-                            TextSpan(
-                              text: account.total?.toCurrency(),
-                              style: Theme.of(context).textTheme.titleSmall,
-                            ),
-                            TextSpan(
-                              text: currencyState.selectedCurrency.symbol,
-                              style:
-                                  Theme.of(context).textTheme.bodySmall?.apply(
-                                fontFeatures: [const FontFeature.subscripts()],
+                      BlurWidget(
+                        child: RichText(
+                          text: TextSpan(
+                            children: [
+                              TextSpan(
+                                text: account.total?.toCurrency(),
+                                style: Theme.of(context).textTheme.titleSmall,
                               ),
-                            ),
-                          ],
+                              TextSpan(
+                                text: currencyState.selectedCurrency.symbol,
+                                style:
+                                    Theme.of(context).textTheme.bodySmall?.apply(
+                                  fontFeatures: [const FontFeature.subscripts()],
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ],

--- a/lib/ui/widgets/blur_widget.dart
+++ b/lib/ui/widgets/blur_widget.dart
@@ -1,0 +1,32 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../pages/structure.dart';
+
+class BlurWidget extends ConsumerWidget {
+  const BlurWidget({super.key, required this.child, this.blur = true});
+
+  final Widget child;
+
+  final bool blur;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    if (!blur) return child;
+
+    final isVisible = ref.watch(visibilityAmountProvider);
+    if (isVisible) return child;
+
+    return ClipRRect(
+      child: ImageFiltered(
+        imageFilter: ImageFilter.blur(sigmaX: 4.5, sigmaY: 4.5),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6.0, vertical: 2.0),
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/widgets/budget_circular_indicator.dart
+++ b/lib/ui/widgets/budget_circular_indicator.dart
@@ -4,6 +4,7 @@ import 'package:percent_indicator/circular_percent_indicator.dart';
 import '../../providers/currency_provider.dart';
 import '../device.dart';
 import '../extensions.dart';
+import 'blur_widget.dart';
 
 /// This class shows account summaries in dashboard
 class BudgetCircularIndicator extends ConsumerWidget {
@@ -11,6 +12,7 @@ class BudgetCircularIndicator extends ConsumerWidget {
   final num amount;
   final double perc;
   final Color color;
+  final bool blurAmounts;
 
   const BudgetCircularIndicator({
     super.key,
@@ -18,6 +20,7 @@ class BudgetCircularIndicator extends ConsumerWidget {
     required this.amount,
     required this.perc,
     required this.color,
+    required this.blurAmounts,
   });
 
   @override
@@ -35,27 +38,30 @@ class BudgetCircularIndicator extends ConsumerWidget {
           center: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              RichText(
-                text: TextSpan(
-                  children: [
-                    TextSpan(
-                      text: amount.toCurrency(),
-                      style: Theme.of(context).textTheme.titleMedium!.copyWith(
-                          color: Theme.of(context).colorScheme.primary),
-                    ),
-                    TextSpan(
-                      text: currencyState.selectedCurrency.symbol,
-                      style: Theme.of(context)
-                          .textTheme
-                          .labelMedium!
-                          .copyWith(
-                            color: Theme.of(context).colorScheme.primary,
-                          )
-                          .apply(
-                        fontFeatures: [const FontFeature.subscripts()],
+              BlurWidget(
+                blur: blurAmounts,
+                child: RichText(
+                  text: TextSpan(
+                    children: [
+                      TextSpan(
+                        text: amount.toCurrency(),
+                        style: Theme.of(context).textTheme.titleMedium!.copyWith(
+                            color: Theme.of(context).colorScheme.primary),
                       ),
-                    ),
-                  ],
+                      TextSpan(
+                        text: currencyState.selectedCurrency.symbol,
+                        style: Theme.of(context)
+                            .textTheme
+                            .labelMedium!
+                            .copyWith(
+                              color: Theme.of(context).colorScheme.primary,
+                            )
+                            .apply(
+                          fontFeatures: [const FontFeature.subscripts()],
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               ),
               const SizedBox(height: Sizes.sm),

--- a/lib/ui/widgets/transactions_list.dart
+++ b/lib/ui/widgets/transactions_list.dart
@@ -9,6 +9,7 @@ import '../../providers/currency_provider.dart';
 import '../../providers/transactions_provider.dart';
 import '../device.dart';
 import '../extensions.dart';
+import 'blur_widget.dart';
 import 'default_container.dart';
 import 'rounded_icon.dart';
 
@@ -18,11 +19,13 @@ class TransactionsList extends StatefulWidget {
     required this.transactions,
     this.margin = const EdgeInsets.symmetric(horizontal: Sizes.lg),
     this.padding,
+    this.blurAmounts = false,
   });
 
   final List<Transaction> transactions;
   final EdgeInsetsGeometry? margin;
   final EdgeInsetsGeometry? padding;
+  final bool blurAmounts;
 
   @override
   State<TransactionsList> createState() => _TransactionsListState();
@@ -83,6 +86,7 @@ class _TransactionsListState extends State<TransactionsList> {
                 return Column(
                   children: [
                     TransactionTitle(
+                      blurAmounts: widget.blurAmounts,
                       date: DateTime.parse(currentDate),
                       total: totals[currentDate] ?? 0,
                     ),
@@ -107,6 +111,7 @@ class _TransactionsListState extends State<TransactionsList> {
                           ),
                           itemBuilder: (context, index) => TransactionTile(
                             transaction: dateTransactions[index],
+                            blurAmounts: widget.blurAmounts,
                           ),
                         ),
                       ),
@@ -121,9 +126,15 @@ class _TransactionsListState extends State<TransactionsList> {
 }
 
 class TransactionTile extends ConsumerWidget {
-  const TransactionTile({required this.transaction, super.key});
+  const TransactionTile({
+    required this.transaction,
+    super.key,
+    required this.blurAmounts,
+  });
 
   final Transaction transaction;
+
+  final bool blurAmounts;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -178,28 +189,31 @@ class TransactionTile extends ConsumerWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.end,
           children: [
-            Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(
-                  '${transaction.type == TransactionType.expense ? "-" : ""}${transaction.amount.toCurrency()}',
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                        color: transaction.type.toColor(
-                          brightness: Theme.of(context).brightness,
+            BlurWidget(
+              blur: blurAmounts,
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    '${transaction.type == TransactionType.expense ? "-" : ""}${transaction.amount.toCurrency()}',
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                          color: transaction.type.toColor(
+                            brightness: Theme.of(context).brightness,
+                          ),
                         ),
-                      ),
-                ),
-                Text(
-                  currencyState.selectedCurrency.symbol,
-                  overflow: TextOverflow.ellipsis,
-                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: transaction.type.toColor(
-                          brightness: Theme.of(context).brightness,
+                  ),
+                  Text(
+                    currencyState.selectedCurrency.symbol,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: transaction.type.toColor(
+                            brightness: Theme.of(context).brightness,
+                          ),
                         ),
-                      ),
-                ),
-              ],
+                  ),
+                ],
+              ),
             ),
             Text(
               transaction.type == TransactionType.transfer
@@ -219,11 +233,13 @@ class TransactionTile extends ConsumerWidget {
 class TransactionTitle extends ConsumerWidget {
   final DateTime date;
   final num total;
+  final bool blurAmounts;
 
   const TransactionTitle({
     super.key,
     required this.date,
     required this.total,
+    required this.blurAmounts,
   });
 
   @override
@@ -242,15 +258,23 @@ class TransactionTitle extends ConsumerWidget {
                 .copyWith(color: Theme.of(context).colorScheme.primary),
           ),
           const Spacer(),
-          Text(
-            total.toCurrency(),
-            style:
-                Theme.of(context).textTheme.bodyLarge!.copyWith(color: color),
+          BlurWidget(
+            blur: blurAmounts,
+            child: Text(
+              total.toCurrency(),
+              style:
+                  Theme.of(context).textTheme.bodyLarge!.copyWith(color: color),
+            ),
           ),
-          Text(
-            currencyState.selectedCurrency.symbol,
-            style:
-                Theme.of(context).textTheme.labelMedium!.copyWith(color: color),
+          BlurWidget(
+            blur: blurAmounts,
+            child: Text(
+              currencyState.selectedCurrency.symbol,
+              style: Theme.of(context)
+                  .textTheme
+                  .labelMedium!
+                  .copyWith(color: color),
+            ),
           ),
         ],
       ),

--- a/lib/utils/app_theme.dart
+++ b/lib/utils/app_theme.dart
@@ -97,7 +97,9 @@ class AppTheme {
     filledButtonTheme: FilledButtonThemeData(
       style: ButtonStyle(
         padding: WidgetStatePropertyAll(EdgeInsets.all(Sizes.xs)),
-        iconSize: WidgetStatePropertyAll(28),
+        iconSize: WidgetStatePropertyAll(24),
+        maximumSize: WidgetStatePropertyAll(Size.square(32)),
+        minimumSize: WidgetStatePropertyAll(Size.square(32)),
         shape: WidgetStatePropertyAll(
           RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(Sizes.borderRadius)),


### PR DESCRIPTION
## 🎯 Description

Like other apps, it could be useful to add a button to hide or show the balance of the account.

Closes: # (issue)  

#406 

- Reflect changes made on [figma](https://www.figma.com/design/6NyY9yqunpbU7HIkbNEAL3/Sossoldi-App?node-id=9977-36882&t=byLhKNyvyzPdqZSV-4)

## 🧪 Testing Instructions

### Behaviour
1. Go on home page
2. Press icon on top to show/hide balance


## 📸 Screenshots / Screen Recordings (if applicable)

<img src="https://github.com/user-attachments/assets/1c72b4ee-fd90-4724-8608-4b109f435807" width="300">
<img src="https://github.com/user-attachments/assets/6f4278f9-a8da-48d6-b481-5fb1ea298791" width="300">


## ✍️ Additional Context

@theperu let me know if I have to change something. The show/hide behavior does not persist.
