### PR TITLE
Fix overflow issue to create new budgets

### DIFF
--- a/lib/pages/planning/manage_budget_page.dart
+++ b/lib/pages/planning/manage_budget_page.dart
@@ -103,7 +103,7 @@ class _ManageBudgetPageState extends ConsumerState<ManageBudgetPage> {
             Expanded(
               child: Column(
                 children: [
-                  Expanded(
+                  Expanded( 
                     child: ListView.builder(
                       shrinkWrap: true,
                       itemCount: budgets.length,

--- a/lib/pages/planning/manage_budget_page.dart
+++ b/lib/pages/planning/manage_budget_page.dart
@@ -103,49 +103,51 @@ class _ManageBudgetPageState extends ConsumerState<ManageBudgetPage> {
             Expanded(
               child: Column(
                 children: [
-                  ListView.builder(
-                    shrinkWrap: true,
-                    itemCount: budgets.length,
-                    itemBuilder: (context, index) {
-                      return Dismissible(
-                        key: Key(budgets[index].idCategory.toString()),
-                        background: Container(
-                          padding: const EdgeInsets.only(right: Sizes.lg),
-                          alignment: Alignment.centerRight,
-                          color: Colors.red,
-                          child: const Text(
-                            'Delete',
-                            textAlign: TextAlign.right,
-                            style: TextStyle(color: Colors.white),
+                  Expanded(
+                    child: ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: budgets.length,
+                      itemBuilder: (context, index) {
+                        return Dismissible(
+                          key: Key(budgets[index].idCategory.toString()),
+                          background: Container(
+                            padding: const EdgeInsets.only(right: Sizes.lg),
+                            alignment: Alignment.centerRight,
+                            color: Colors.red,
+                            child: const Text(
+                              'Delete',
+                              textAlign: TextAlign.right,
+                              style: TextStyle(color: Colors.white),
+                            ),
                           ),
-                        ),
-                        onDismissed: (direction) {
-                          deleteBudget(budgets[index], index);
-                        },
-                        child: BudgetCategorySelector(
-                          categories: categories,
-                          categoriesAlreadyUsed: categories
-                              .where((element) => budgets
-                                  .map((e) => e.name)
-                                  .contains(element.name))
-                              .map((e) => e.name)
-                              .toList(),
-                          budget: budgets[index],
-                          initSelectedCategory: categories
-                                  .where((element) =>
-                                      element.id == budgets[index].idCategory)
-                                  .isEmpty
-                              ? categories[0]
-                              : categories
-                                  .where((element) =>
-                                      element.id == budgets[index].idCategory)
-                                  .first,
-                          onBudgetChanged: (updatedBudget) {
-                            updateBudget(updatedBudget, index);
+                          onDismissed: (direction) {
+                            deleteBudget(budgets[index], index);
                           },
-                        ),
-                      );
-                    },
+                          child: BudgetCategorySelector(
+                            categories: categories,
+                            categoriesAlreadyUsed: categories
+                                .where((element) => budgets
+                                    .map((e) => e.name)
+                                    .contains(element.name))
+                                .map((e) => e.name)
+                                .toList(),
+                            budget: budgets[index],
+                            initSelectedCategory: categories
+                                    .where((element) =>
+                                        element.id == budgets[index].idCategory)
+                                    .isEmpty
+                                ? categories[0]
+                                : categories
+                                    .where((element) =>
+                                        element.id == budgets[index].idCategory)
+                                    .first,
+                            onBudgetChanged: (updatedBudget) {
+                              updateBudget(updatedBudget, index);
+                            },
+                          ),
+                        );
+                      },
+                    ),
                   ),
                   const SizedBox(height: Sizes.sm),
                   Text("Swipe left to delete",

--- a/lib/pages/planning/manage_budget_page.dart
+++ b/lib/pages/planning/manage_budget_page.dart
@@ -103,51 +103,49 @@ class _ManageBudgetPageState extends ConsumerState<ManageBudgetPage> {
             Expanded(
               child: Column(
                 children: [
-                  Expanded(
-                    child: ListView.builder(
-                      shrinkWrap: true,
-                      itemCount: budgets.length,
-                      itemBuilder: (context, index) {
-                        return Dismissible(
-                          key: Key(budgets[index].idCategory.toString()),
-                          background: Container(
-                            padding: const EdgeInsets.only(right: Sizes.lg),
-                            alignment: Alignment.centerRight,
-                            color: Colors.red,
-                            child: const Text(
-                              'Delete',
-                              textAlign: TextAlign.right,
-                              style: TextStyle(color: Colors.white),
-                            ),
+                  ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: budgets.length,
+                    itemBuilder: (context, index) {
+                      return Dismissible(
+                        key: Key(budgets[index].idCategory.toString()),
+                        background: Container(
+                          padding: const EdgeInsets.only(right: Sizes.lg),
+                          alignment: Alignment.centerRight,
+                          color: Colors.red,
+                          child: const Text(
+                            'Delete',
+                            textAlign: TextAlign.right,
+                            style: TextStyle(color: Colors.white),
                           ),
-                          onDismissed: (direction) {
-                            deleteBudget(budgets[index], index);
+                        ),
+                        onDismissed: (direction) {
+                          deleteBudget(budgets[index], index);
+                        },
+                        child: BudgetCategorySelector(
+                          categories: categories,
+                          categoriesAlreadyUsed: categories
+                              .where((element) => budgets
+                                  .map((e) => e.name)
+                                  .contains(element.name))
+                              .map((e) => e.name)
+                              .toList(),
+                          budget: budgets[index],
+                          initSelectedCategory: categories
+                                  .where((element) =>
+                                      element.id == budgets[index].idCategory)
+                                  .isEmpty
+                              ? categories[0]
+                              : categories
+                                  .where((element) =>
+                                      element.id == budgets[index].idCategory)
+                                  .first,
+                          onBudgetChanged: (updatedBudget) {
+                            updateBudget(updatedBudget, index);
                           },
-                          child: BudgetCategorySelector(
-                            categories: categories,
-                            categoriesAlreadyUsed: categories
-                                .where((element) => budgets
-                                    .map((e) => e.name)
-                                    .contains(element.name))
-                                .map((e) => e.name)
-                                .toList(),
-                            budget: budgets[index],
-                            initSelectedCategory: categories
-                                    .where((element) =>
-                                        element.id == budgets[index].idCategory)
-                                    .isEmpty
-                                ? categories[0]
-                                : categories
-                                    .where((element) =>
-                                        element.id == budgets[index].idCategory)
-                                    .first,
-                            onBudgetChanged: (updatedBudget) {
-                              updateBudget(updatedBudget, index);
-                            },
-                          ),
-                        );
-                      },
-                    ),
+                        ),
+                      );
+                    },
                   ),
                   const SizedBox(height: Sizes.sm),
                   Text("Swipe left to delete",


### PR DESCRIPTION
## 🎯 Description

As mentioned in #454, changes were made so any number of budgets can be added in the planning screen 

Closes: #454 

## 📱 Changes

Wrapped ListView widget in manage_budget_page with Expanded 
## 🧪 Testing Instructions

### Behaviour

After making this changes now n number of budgets can be added

## 📸 Screenshots / Screen Recordings (if applicable)

If your PR involves UI changes, please add screenshots or screen recordings here.

before:
<img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/a21590e5-dbd9-413e-b9b8-ca689a75f787" />

after:
<img width="1290" height="2796" alt="image" src="https://github.com/user-attachments/assets/a24b566a-eba9-4d9d-a7ed-ce8435f4ba81" />


## 🔍 Checklist for reviewers
- [ ] Code is formatted correctly
- [ ] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [ ] Android


## ✍️ Additional Context

Add any other information that we might know 
