### PR TITLE
Fix list tile height & currency symbol in month selector

### DIFF
--- a/lib/pages/transactions/widgets/account_list_tile.dart
+++ b/lib/pages/transactions/widgets/account_list_tile.dart
@@ -113,7 +113,6 @@ class AccountListTile extends ConsumerWidget {
           expand: selectedAccountIndex == index,
           child: Container(
             color: Theme.of(context).colorScheme.primaryContainer,
-            height: 70.0 * nTransactions,
             child: ListView.separated(
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),

--- a/lib/pages/transactions/widgets/category_list_tile.dart
+++ b/lib/pages/transactions/widgets/category_list_tile.dart
@@ -110,7 +110,6 @@ class CategoryListTile extends ConsumerWidget {
           expand: selectedCategoryIndex == index,
           child: Container(
             color: Theme.of(context).colorScheme.primaryContainer,
-            height: 70.0 * nTransactions,
             child: ListView.separated(
               shrinkWrap: true,
               physics: const NeverScrollableScrollPhysics(),

--- a/lib/pages/transactions/widgets/month_selector.dart
+++ b/lib/pages/transactions/widgets/month_selector.dart
@@ -114,13 +114,6 @@ class MonthSelector extends ConsumerWidget {
                                 .labelLarge!
                                 .copyWith(
                                     color: totalAmount >= 0 ? green : red)),
-                        TextSpan(
-                            text: currencyState.selectedCurrency.symbol,
-                            style: Theme.of(context)
-                                .textTheme
-                                .labelLarge!
-                                .copyWith(
-                                    color: totalAmount >= 0 ? green : red)),
                       ],
                     ),
                   ),


### PR DESCRIPTION
## 🎯 Description

Please provide a clear and concise description of what this pull request does.  
Explain why this change is necessary and what problem it solves.  

Closes: #456 & #457 

## 📱 Changes

- Removed fixed height for the transaction tile
- Removed one of the currency symbols

## 🧪 Testing Instructions

### Behaviour
1. Check the account and category lists of transactions and make sure that the last one is not cut
2. Check that in the month selector there is only one currency symbol


## 📸 Screenshots / Screen Recordings (if applicable)

If your PR involves UI changes, please add screenshots or screen recordings here.

| Platform | Before | After |
|----------|--------|-------|
| Transaction tile  |    <img width="640" height="1222" alt="481005991-dd2bed54-3c8d-4991-b1be-5d52c4d65978" src="https://github.com/user-attachments/assets/fa388b63-b4fc-4127-8c06-13328b467d6a" />   |   <img width="640" height="1222" alt="Screenshot 2025-08-22 at 16 30 36" src="https://github.com/user-attachments/assets/e3c752b7-0d9c-49b2-b7f6-039867d617ce" />    |
| Currency symbol      |    <img width="433" height="134" alt="Screenshot 2025-08-22 at 15 42 37" src="https://github.com/user-attachments/assets/ca20cf38-11ac-4d83-9f59-cab6e1e7a930" />    |    <img width="454" height="140" alt="Screenshot 2025-08-22 at 16 29 01" src="https://github.com/user-attachments/assets/dbae8a95-7c45-4518-8969-26297b9f2f23" />   |


## 🔍 Checklist for reviewers
- [X] Code is formatted correctly
- [X] Tests are passing
- [X] New tests are added (if needed)
- [X] Style matches the figma/designer requests
- Tested on:
    - [X] iOS
    - [X] Android


## ✍️ Additional Context

N/A
