### PR TITLE
fixed state sync issue for transaction and recurring transaction page

### DIFF
--- a/lib/pages/planning/widget/recurring_payments_list.dart
+++ b/lib/pages/planning/widget/recurring_payments_list.dart
@@ -7,7 +7,6 @@ import '../../../providers/transactions_provider.dart';
 import '../../../model/recurring_transaction.dart';
 import '../../../model/transaction.dart';
 
-
 class RecurringPaymentSection extends ConsumerStatefulWidget {
   const RecurringPaymentSection({super.key});
 

--- a/lib/pages/transactions/create_transaction/create_transaction_page.dart
+++ b/lib/pages/transactions/create_transaction/create_transaction_page.dart
@@ -127,6 +127,8 @@ class _CreateTransactionPage extends ConsumerState<CreateTransactionPage> {
 
   // TODO: This should be inside addTransaction
   void _refreshAccountAndNavigateBack() {
+    ref.invalidate(transactionsProvider);
+    ref.invalidate(recurringTransactionProvider);
     ref
         .read(accountsProvider.notifier)
         .refreshAccount(ref.read(bankAccountProvider)!)

--- a/lib/providers/transactions_provider.dart
+++ b/lib/providers/transactions_provider.dart
@@ -14,6 +14,11 @@ final lastTransactionsProvider = FutureProvider<List<Transaction>>((ref) async {
   return transactions;
 });
 
+var recurringTransactionProvider =
+    FutureProvider<List<RecurringTransaction>>((ref) {
+  return RecurringTransactionMethods().selectAllActive();
+});
+
 final transactionTypeList = Provider<List<TransactionType>>((ref) => [
       TransactionType.income,
       TransactionType.expense,


### PR DESCRIPTION
## 🎯 Description

when create button clicked in bottom nav bar floating action button
 to add transaction( specifically recurring transaction ) when we add it its not reflecting immediately in transaction -> list screen and planning -> recurring payment section screen 

because the state is not updating correctly so with this changes now once we add recurring transaction via floating action button automatically the transaction should be updated in both screen without need of navigating back to diff screen and coming back to the screen to see the updated recurring transaction

Closes: #463 

## 📱 Changes

- [x] Describe key changes made
- [x] List any new features, bug fixes, or refactors
- [x] Include additional details if necessary

## 🧪 Testing Instructions

### Behaviour
1. Do this
2. Do that


## 📸 Screenshots / Screen Recordings (if applicable)

If your PR involves UI changes, please add screenshots or screen recordings here.

| Platform | Before | After |
|----------|--------|-------|
| Android  |        |       |
| iOS      |        |       |


## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [x] New tests are added (if needed)
- [x] Style matches the figma/designer requests
- Tested on:
    - [x] iOS
    - [x] Android


## ✍️ Additional Context

Add any other information that we might know 
