### PR TITLE
Support old backups that have no type for recurringTransaction

### DIFF
--- a/lib/services/database/sossoldi_database.dart
+++ b/lib/services/database/sossoldi_database.dart
@@ -177,12 +177,13 @@ class SossoldiDatabase {
                   }
                 }
               }
-              
+
               // Default 'type' to 'OUT' for old recurringTransaction backups
-              if (tableName == 'recurringTransaction' && !row.containsKey('type')) {
+              if (tableName == 'recurringTransaction' &&
+                  !row.containsKey('type')) {
                 row['type'] = 'OUT';
               }
-              
+
               await txn.insert(tableName, row);
             }
             results[tableName] = true;

--- a/lib/services/database/sossoldi_database.dart
+++ b/lib/services/database/sossoldi_database.dart
@@ -177,6 +177,12 @@ class SossoldiDatabase {
                   }
                 }
               }
+              
+              // Default 'type' to 'OUT' for old recurringTransaction backups
+              if (tableName == 'recurringTransaction' && !row.containsKey('type')) {
+                row['type'] = 'OUT';
+              }
+              
               await txn.insert(tableName, row);
             }
             results[tableName] = true;


### PR DESCRIPTION
## 🎯 Description

After enabling recurring transactions for income and transfers the backups created before can't be imported because they are missing the type (like IN, OUT, TRSF)

Closes: #468 

## 📱 Changes

In the import function if a recurringTransaction entry doesn't have a type we automatically assign the type `OUT` since it was the only one supported before

## 🧪 Testing Instructions

### Behaviour
1. Create a backup with the current version of the app in the stores
2. Install this version of the app
3. Try to import the backup and make sure that the action completes without errors


## 📸 Screenshots / Screen Recordings (if applicable)

N/A


## 🔍 Checklist for reviewers
- [X] Code is formatted correctly
- [X] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [X] iOS
    - [X] Android


## ✍️ Additional Context

Add any other information that we might know 
