### PR TITLE
Fix available liquidity calculation

### DIFF
--- a/lib/providers/statistics_provider.dart
+++ b/lib/providers/statistics_provider.dart
@@ -2,6 +2,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../model/transaction.dart';
+import 'accounts_provider.dart';
 
 final currentYearMontlyTransactionsProvider =
     StateProvider<List<FlSpot>>((ref) => const []);
@@ -10,11 +11,30 @@ final statisticsProvider = FutureProvider<void>((ref) async {
   final currentYearMontlyTransaction =
       await TransactionMethods().currentYearMontlyTransactions();
 
-  double runningTotal = 0;
-  ref.read(currentYearMontlyTransactionsProvider.notifier).state =
-      currentYearMontlyTransaction.map((e) {
-    runningTotal += e['income'] - e['expense'];
-    return FlSpot(double.parse(e['month'].substring(5)) - 1,
-        double.parse(runningTotal.toStringAsFixed(2)));
-  }).toList();
+  final accountsAsync = ref.read(accountsProvider);
+  final accounts = accountsAsync.value ?? [];
+  double currentBalance =
+      accounts.fold(0.0, (sum, account) => sum + (account.total ?? 0));
+
+  List<FlSpot> spots = [];
+  double runningBalance = currentBalance;
+
+  final reversedTransactions = currentYearMontlyTransaction.reversed.toList();
+
+  for (int i = 0; i < reversedTransactions.length; i++) {
+    final monthData = reversedTransactions[i];
+    final monthIndex = double.parse(monthData['month'].substring(5)) - 1;
+
+    spots.add(
+        FlSpot(monthIndex, double.parse(runningBalance.toStringAsFixed(2))));
+
+    if (i < reversedTransactions.length - 1) {
+      runningBalance =
+          runningBalance - monthData['income'] + monthData['expense'];
+    }
+  }
+
+  spots.sort((a, b) => a.x.compareTo(b.x));
+
+  ref.read(currentYearMontlyTransactionsProvider.notifier).state = spots;
 });


### PR DESCRIPTION
## 🎯 Description

Fix available liquidity calculation. Currently we were only showing the difference between incomes and expenses without counting the account balances.

Closes: #446 

## 📱 Changes

Changed how the liquidity is calculated. Now it works like this:
- For the current month the liquidity is simply the sum of all the accounts
- Each previous month is calculated by subtracting each income transaction and adding each expense of the next month

Ex. We are in September and the current liquidity is calculated by adding the balance of each account, for August the liquidity would be the one from September minus all the income from September and plus all the expenses from September (in this way we restore the liquidity that the user had at the end of August).

## 🧪 Testing Instructions

### Behaviour
1. Open the graph page
2. Check that the liquidity for the current month and previous ones is calculated correctly


## 🔍 Checklist for reviewers
- [ ] Code is formatted correctly
- [ ] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [ ] Android
