### PR TITLE
fix (migration): type in recurring real to text

### DIFF
--- a/lib/model/recurring_transaction.dart
+++ b/lib/model/recurring_transaction.dart
@@ -26,6 +26,7 @@ class RecurringTransactionFields extends BaseEntityFields {
     toDate,
     amount,
     note,
+    type,
     recurrency,
     idCategory,
     idBankAccount,

--- a/lib/services/database/migrations/0003_recurring_transaction_type.dart
+++ b/lib/services/database/migrations/0003_recurring_transaction_type.dart
@@ -11,11 +11,11 @@ class RecurringTransactionType extends Migration {
 
   @override
   Future<void> up(Database db) async {
-    const realNotNull = 'REAL NOT NULL';
+    const textNotNull = 'TEXT NOT NULL';
 
     // Bank accounts Table
     await db.execute('''
-      ALTER TABLE `$recurringTransactionTable` ADD COLUMN `${RecurringTransactionFields.type}` $realNotNull;
+      ALTER TABLE `$recurringTransactionTable` ADD COLUMN `${RecurringTransactionFields.type}` $textNotNull DEFAULT 'OUT';
       ''');
   }
 }

--- a/lib/services/database/migrations/0004_recurring_transaction_type_text.dart
+++ b/lib/services/database/migrations/0004_recurring_transaction_type_text.dart
@@ -1,0 +1,36 @@
+import 'package:sqflite/sqflite.dart';
+import '../migration_base.dart';
+
+// Models
+import '/model/recurring_transaction.dart';
+
+class RecurringTransactionTypeText extends Migration {
+  RecurringTransactionTypeText()
+      : super(
+            version: 4,
+            description:
+                'Change type column to text not null with default OUT');
+
+  @override
+  Future<void> up(Database db) async {
+    // Step 1: Rename existing column
+    await db.execute('''
+      ALTER TABLE `$recurringTransactionTable` RENAME COLUMN `${RecurringTransactionFields.type}` TO `${RecurringTransactionFields.type}_old`;
+      ''');
+
+    // Step 2: Add new column with correct type and default
+    await db.execute('''
+      ALTER TABLE `$recurringTransactionTable` ADD COLUMN `${RecurringTransactionFields.type}` TEXT NOT NULL DEFAULT 'OUT';
+      ''');
+
+    // Step 3: Copy data from old column to new column
+    await db.execute('''
+      UPDATE `$recurringTransactionTable` SET `${RecurringTransactionFields.type}` = `${RecurringTransactionFields.type}_old`;
+      ''');
+
+    // Step 4: Drop the old column
+    await db.execute('''
+      ALTER TABLE `$recurringTransactionTable` DROP COLUMN `${RecurringTransactionFields.type}_old`;
+      ''');
+  }
+}

--- a/lib/services/database/migrations/migration_registry.dart
+++ b/lib/services/database/migrations/migration_registry.dart
@@ -14,6 +14,7 @@ library;
 import '0001_initial_schema.dart';
 import '0002_account_net_worth.dart';
 import '0003_recurring_transaction_type.dart';
+import '0004_recurring_transaction_type_text.dart';
 import '../migration_base.dart';
 
 /// Returns all available migrations in execution order.
@@ -27,6 +28,7 @@ List<Migration> getMigrations() {
     InitialSchema(),
     AccountNetWorth(),
     RecurringTransactionType(),
+    RecurringTransactionTypeText(),
     // Add future migrations here
   ];
 }


### PR DESCRIPTION
## 🎯 Description

After enabling recurring transactions for income and transfers the backups created before can't be imported because they are missing the type (like IN, OUT, TRSF)

Closes: #468 

## 📱 Changes

- Add a migration that fix the type of column type from real to text and set default to out, so also during import it does get it by default if the field is empty.

## 🧪 Testing Instructions

### Behaviour
1. Create a backup with the current version of the app in the stores
2. Install this version of the app
3. Try to import the backup and make sure that the action completes without errors

## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [x] Android

