### PR TITLE
fix (migration): type in recurring real to text

### DIFF
--- a/lib/model/recurring_transaction.dart
+++ b/lib/model/recurring_transaction.dart
@@ -26,6 +26,7 @@ class RecurringTransactionFields extends BaseEntityFields {
     toDate,
     amount,
     note,
+    type,
     recurrency,
     idCategory,
     idBankAccount,

--- a/lib/services/database/migrations/0003_recurring_transaction_type.dart
+++ b/lib/services/database/migrations/0003_recurring_transaction_type.dart
@@ -11,11 +11,11 @@ class RecurringTransactionType extends Migration {
 
   @override
   Future<void> up(Database db) async {
-    const realNotNull = 'REAL NOT NULL';
+    const textNotNull = 'TEXT NOT NULL';
 
     // Bank accounts Table
     await db.execute('''
-      ALTER TABLE `$recurringTransactionTable` ADD COLUMN `${RecurringTransactionFields.type}` $realNotNull;
+      ALTER TABLE `$recurringTransactionTable` ADD COLUMN `${RecurringTransactionFields.type}` $textNotNull DEFAULT 'OUT';
       ''');
   }
 }


### PR DESCRIPTION
## 🎯 Description

After enabling recurring transactions for income and transfers the backups created before can't be imported because they are missing the type (like IN, OUT, TRSF)

Closes: #468 

## 📱 Changes

- Add a migration that fix the type of column type from real to text and set default to out, so also during import it does get it by default if the field is empty.

## 🧪 Testing Instructions

### Behaviour
1. Create a backup with the current version of the app in the stores
2. Install this version of the app
3. Try to import the backup and make sure that the action completes without errors

## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [x] Android

