### PR TITLE
Persist last used value for balance blurring in SharedPreferences

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -88,9 +88,6 @@ void main() async {
           overrides: [
             versionProvider.overrideWithValue(packageInfo.version),
             sharedPrefProvider.overrideWithValue(sharedPreferences),
-            visibilityAmountProvider.overrideWith(
-              () => VisibilityAmount(sharedPreferences),
-            ),
           ],
           child: const Launcher(),
         ),

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -19,10 +19,6 @@ bool onBoardingCompleted(Ref ref) {
 
 @Riverpod(keepAlive: true)
 class VisibilityAmount extends _$VisibilityAmount {
-  VisibilityAmount([SharedPreferences? prefs]) : _prefs = prefs;
-
-  final SharedPreferences? _prefs;
-
   @override
   bool build() {
     final SharedPreferences prefs = ref.watch(sharedPrefProvider);

--- a/test/widget/accounts_sum_test.dart
+++ b/test/widget/accounts_sum_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sossoldi/services/database/sossoldi_database.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:flutter/material.dart';
@@ -8,16 +9,20 @@ import "dart:math";
 import 'package:sossoldi/model/bank_account.dart';
 import 'package:sossoldi/services/database/repositories/account_repository.dart';
 import 'package:sossoldi/pages/dashboard/widgets/accounts_sum.dart';
+import 'package:sossoldi/providers/settings_provider.dart';
 
 void main() {
   // Initialize the database factory with sqflite_common_ffi
   databaseFactory = databaseFactoryFfi;
 
   late SossoldiDatabase sossoldiDatabase;
+  late SharedPreferences sharedPreferences;
 
   setUpAll(() async {
     sossoldiDatabase = SossoldiDatabase(dbName: 'test.db');
     await sossoldiDatabase.clearDatabase();
+    SharedPreferences.setMockInitialValues({'visibility_amount': false});
+    sharedPreferences = await SharedPreferences.getInstance();
   });
 
   tearDown(() async => await sossoldiDatabase.clearDatabase());
@@ -47,7 +52,12 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
-          child: ProviderScope(child: AccountsSum(account: randomBankAccount)),
+          child: ProviderScope(
+            overrides: [
+              sharedPrefProvider.overrideWithValue(sharedPreferences),
+            ],
+            child: AccountsSum(account: randomBankAccount),
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## 🎯 Description

Sorry for closing [the other PR](https://github.com/RIP-Comm/sossoldi/pull/490), i messed up with my git repo after merging #489 

Blurring balance was always active by default, every time you open the application. Let's save the last used value on sharedpref, and use that instead.

## 📱 Changes

- Passed the sharePreferences dependency on main to the visibilityAmountProvider
- Make the settings read from that

## 🧪 Testing Instructions

### Behaviour
1. Tap balance visibility button to see/blur values
2. Close the app
3. Open the app, check if the last value is used


## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [x] Style matches the figma/designer requests
- Tested on:
    - [x] iOS
    - [x] Android

