### PR TITLE
fix: tap and drag on chart

### DIFF
--- a/lib/ui/widgets/line_chart.dart
+++ b/lib/ui/widgets/line_chart.dart
@@ -229,8 +229,15 @@ class _LineChartSample2State extends State<LineChartWidget> {
           getTooltipItems: (List<LineBarSpot> touchedBarSpots) {
             bool allSameX = touchedBarSpots.map((e) => e.x).toSet().length == 1;
 
-            if (!allSameX || touchedBarSpots.isEmpty) {
+            if (touchedBarSpots.isEmpty) {
               return [];
+            }
+
+            if (!allSameX) {
+              return List.generate(
+                touchedBarSpots.length,
+                (_) => const LineTooltipItem('', TextStyle()),
+              );
             }
 
             double x = touchedBarSpots[0].x;


### PR DESCRIPTION
## 🎯 Description

Fix a widget error on the console for the charts when moving from a section with 2 lines to the other with 1 line or 
opposite.

Closes: #369 

## 🧪 Testing Instructions
Test on debug and check the console that the error is no more visible.

## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [ ] New tests are added (if needed)
- [x] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [x] Android
