### PR TITLE
fix: transaction empty state wrong show

### DIFF
--- a/lib/pages/transactions/transactions_page.dart
+++ b/lib/pages/transactions/transactions_page.dart
@@ -1,13 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../constants/style.dart';
 import '../../providers/transactions_provider.dart';
-import '../../ui/assets.dart';
-import '../../ui/device.dart';
 import '../../ui/snack_bars/transactions_snack_bars.dart';
-import '../../ui/widgets/default_container.dart';
 import 'widgets/accounts_tab.dart';
+import 'widgets/add_transaction_card.dart';
 import 'widgets/categories_tab.dart';
 import 'widgets/custom_sliver_delegate.dart';
 import 'widgets/list_tab.dart';
@@ -59,73 +56,11 @@ class _TransactionsPageState extends ConsumerState<TransactionsPage>
         ref: ref,
       ),
     );
-    final transactionsAsync = ref.watch(transactionsProvider);
+    final transactionsExistsAsync = ref.watch(transactionsExistsProvider);
 
-    return transactionsAsync.when(
-      data: (data) {
-        if (data.isEmpty) {
-          return Align(
-            alignment: Alignment.topCenter,
-            child: DefaultContainer(
-              margin: const EdgeInsets.symmetric(
-                horizontal: Sizes.lg,
-                vertical: Sizes.xl,
-              ),
-              child: Column(
-                spacing: 16,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    "There are no transactions added yet",
-                    style: Theme.of(context).textTheme.bodySmall,
-                    textAlign: TextAlign.center,
-                  ),
-                  Image.asset(
-                    SossoldiAssets.calculator,
-                    width: 240,
-                    height: 240,
-                  ),
-                  Text(
-                    "Add a transaction to make this section more appealing",
-                    style: Theme.of(context).textTheme.bodySmall,
-                    textAlign: TextAlign.center,
-                  ),
-                  Container(
-                    width: double.infinity,
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(Sizes.borderRadius),
-                      boxShadow: [defaultShadow],
-                    ),
-                    child: ElevatedButton.icon(
-                      icon: Icon(
-                        Icons.add_circle,
-                        color: Theme.of(context).colorScheme.onPrimaryContainer,
-                        size: Sizes.xl,
-                      ),
-                      label: Text(
-                        "Add transaction",
-                        style: Theme.of(context).textTheme.titleLarge!.apply(
-                          color: Theme.of(
-                            context,
-                          ).colorScheme.onPrimaryContainer,
-                        ),
-                      ),
-                      style: TextButton.styleFrom(
-                        backgroundColor: Theme.of(
-                          context,
-                        ).colorScheme.primaryContainer,
-                        padding: const EdgeInsets.symmetric(vertical: Sizes.md),
-                      ),
-                      onPressed: () {
-                        Navigator.of(context).pushNamed("/add-page");
-                      },
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          );
-        } else {
+    return transactionsExistsAsync.when(
+      data: (transactionsExists) {
+        if (transactionsExists) {
           return NotificationListener<ScrollEndNotification>(
             onNotification: (notification) {
               // snap the header open/close when it's in between the two states
@@ -171,6 +106,8 @@ class _TransactionsPageState extends ConsumerState<TransactionsPage>
             ),
           );
         }
+
+        return const AddTransactionCard();
       },
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, stack) => Center(

--- a/lib/pages/transactions/widgets/add_transaction_card.dart
+++ b/lib/pages/transactions/widgets/add_transaction_card.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+
+import '../../../constants/style.dart';
+import '../../../ui/assets.dart';
+import '../../../ui/device.dart';
+import '../../../ui/widgets/default_container.dart';
+
+class AddTransactionCard extends StatelessWidget {
+  const AddTransactionCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: DefaultContainer(
+        margin: const EdgeInsets.symmetric(
+          horizontal: Sizes.lg,
+          vertical: Sizes.xl,
+        ),
+        child: Column(
+          spacing: 16,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              "There are no transactions added yet",
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            Image.asset(SossoldiAssets.calculator, width: 240, height: 240),
+            Text(
+              "Add a transaction to make this section more appealing",
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            ),
+            Container(
+              width: double.infinity,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(Sizes.borderRadius),
+                boxShadow: [defaultShadow],
+              ),
+              child: ElevatedButton.icon(
+                icon: Icon(
+                  Icons.add_circle,
+                  color: Theme.of(context).colorScheme.onPrimaryContainer,
+                  size: Sizes.xl,
+                ),
+                label: Text(
+                  "Add transaction",
+                  style: Theme.of(context).textTheme.titleLarge!.apply(
+                    color: Theme.of(context).colorScheme.onPrimaryContainer,
+                  ),
+                ),
+                style: TextButton.styleFrom(
+                  backgroundColor: Theme.of(
+                    context,
+                  ).colorScheme.primaryContainer,
+                  padding: const EdgeInsets.symmetric(vertical: Sizes.md),
+                ),
+                onPressed: () {
+                  Navigator.of(context).pushNamed("/add-page");
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/providers/transactions_provider.dart
+++ b/lib/providers/transactions_provider.dart
@@ -148,6 +148,7 @@ class TransactionsNotifier extends _$TransactionsNotifier {
   }
 
   Future<List<Transaction>> _getTransactions({int? limit}) async {
+    ref.invalidate(transactionsExistsProvider);
     ref.invalidate(lastTransactionsProvider);
     ref.invalidate(accountsProvider);
     ref.invalidate(monthlyBudgetsStatsProvider);
@@ -321,6 +322,12 @@ class TransactionsNotifier extends _$TransactionsNotifier {
     ref.invalidate(intervalProvider);
     ref.invalidate(selectedTransactionTypeProvider);
   }
+}
+
+@Riverpod(keepAlive: true)
+Future<bool> transactionsExists(Ref ref) async {
+  final count = await ref.read(transactionsRepositoryProvider).countAll();
+  return count > 0;
 }
 
 @Riverpod(keepAlive: true)

--- a/lib/services/database/repositories/transactions_repository.dart
+++ b/lib/services/database/repositories/transactions_repository.dart
@@ -121,6 +121,18 @@ class TransactionsRepository {
     return result.map((json) => Transaction.fromJson(json)).toList();
   }
 
+  Future<int> countAll() async {
+    final db = await _sossoldiDB.database;
+
+    final result = await db.rawQuery(
+      'SELECT COUNT(*) as count FROM "$transactionTable"',
+    );
+
+    return result.first['count'] != null
+        ? int.parse(result.first['count'].toString())
+        : 0;
+  }
+
   Future<List<String>> getAllLabels({String? label}) async {
     final db = await _sossoldiDB.database;
 

--- a/lib/ui/widgets/transactions_list.dart
+++ b/lib/ui/widgets/transactions_list.dart
@@ -121,13 +121,16 @@ class _TransactionsListState extends State<TransactionsList> {
       );
     }
 
-    return DefaultContainer(
-      margin: widget.margin,
-      child: Text(
-        "Add a transaction to make this section more appealing",
-        style: Theme.of(
-          context,
-        ).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic),
+    return Align(
+      alignment: Alignment.topCenter,
+      child: DefaultContainer(
+        margin: widget.margin,
+        child: Text(
+          "Add a transaction to make this section more appealing",
+          style: Theme.of(
+            context,
+          ).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 🎯 Description

Solve a bug when selecting a month with no transactions in transactions page, it was showing the widget saying no transactions added and blocking the user from doing any other action in the page.

## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [ ] New tests are added (if needed)
- [x] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [x] Android
