### PR TITLE
fix: migrate icons name

### DIFF
--- a/lib/services/database/migrations/0006_migrate_icons_name.dart
+++ b/lib/services/database/migrations/0006_migrate_icons_name.dart
@@ -1,0 +1,19 @@
+// ignore_for_file: file_names
+
+import 'package:sqflite/sqflite.dart';
+import '../migration_base.dart';
+
+// Models
+import '../../../model/category_transaction.dart';
+
+class MigrateIconsName extends Migration {
+  MigrateIconsName()
+    : super(version: 6, description: 'Migrate icons name to match constants');
+
+  @override
+  Future<void> up(Database db) async {
+    await db.rawUpdate(
+      "UPDATE $categoryTransactionTable SET ${CategoryTransactionFields.symbol} = substr(${CategoryTransactionFields.symbol}, 1, length(${CategoryTransactionFields.symbol}) - 8) WHERE ${CategoryTransactionFields.symbol} LIKE '%_rounded'",
+    );
+  }
+}

--- a/lib/services/database/migrations/migration_registry.dart
+++ b/lib/services/database/migrations/migration_registry.dart
@@ -16,6 +16,7 @@ import '0002_account_net_worth.dart';
 import '0003_recurring_transaction_type.dart';
 import '0004_add_category_order.dart';
 import '0005_add_account_order.dart';
+import '0006_migrate_icons_name.dart';
 
 import '../migration_base.dart';
 
@@ -32,6 +33,7 @@ List<Migration> getMigrations() {
     RecurringTransactionType(),
     AddCategoryOrder(),
     AddAccountOrder(),
+    MigrateIconsName(),
   ];
 }
 


### PR DESCRIPTION
## 🎯 Description

Migration to remove old _rounded icon name suffix 

## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [ ] New tests are added (if needed)
- [x] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [x] Android
