### PR TITLE
Dettaglio export popup avviso su android

### DIFF
--- a/lib/services/csv/csv_file_picker.dart
+++ b/lib/services/csv/csv_file_picker.dart
@@ -77,9 +77,9 @@ class CSVFilePicker {
       }
     } catch (e) {
       if (context.mounted) {
-        String errorMessage = 'Cannot save the file here, please create or select a folder in Downloads or Documents. Error: ${e.toString()}';
-        
-        
+        String errorMessage =
+            'Cannot save the file here, please create or select a folder in Downloads or Documents. Error: ${e.toString()}';
+
         showSnackBar(context, message: errorMessage);
       }
     }


### PR DESCRIPTION


## 🎯 Description

quando l'utente prova a salvare nella root directory di android ha un output più chiaro sul perchè non funziona e su dove salvare il file

Closes: # (issue)  

## 📱 Changes

- aggiunto un popup che, nel momento dell'esportazione, durante il salvataggio, se il dispositivo è android, avvisa che il file non può essere salvato in directory root ma in una directory tipo downloads o documents.


## 🧪 Testing Instructions

### Behaviour
1. Apri l'app
2. Prova a esportare nella root directory


## 📸 Screenshots / Screen Recordings (if applicable)

Documentazione dell'errore da utente discord:

https://github.com/user-attachments/assets/e6aa08c4-dc88-42df-b6e1-7a0bee2d3f97



## 🔍 Checklist for reviewers
- [ ] Code is formatted correctly
- [ ] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [ ] Android


## ✍️ Additional Context

Questo errore era stato segnalato su discord da un utente in chat generale.
