### PR TITLE
fix: respect countNetWorth flag when calculating net worth totals

### DIFF
--- a/lib/providers/statistics_provider.dart
+++ b/lib/providers/statistics_provider.dart
@@ -36,10 +36,9 @@ class Statistics extends _$Statistics {
 
     final accountsAsync = ref.read(accountsProvider);
     final accounts = accountsAsync.value ?? [];
-    double currentBalance = accounts.fold(
-      0.0,
-      (sum, account) => sum + (account.total ?? 0),
-    );
+    double currentBalance = accounts
+        .where((account) => account.countNetWorth)
+        .fold(0.0, (sum, account) => sum + (account.total ?? 0));
 
     List<FlSpot> spots = [];
     double runningBalance = currentBalance;

--- a/lib/providers/statistics_provider.dart
+++ b/lib/providers/statistics_provider.dart
@@ -37,7 +37,7 @@ class Statistics extends _$Statistics {
     final accountsAsync = ref.read(accountsProvider);
     final accounts = accountsAsync.value ?? [];
     double currentBalance = accounts
-        .where((account) => account.countNetWorth)
+        .where((account) => account.countNetWorth && account.deletedAt == null)
         .fold(0.0, (sum, account) => sum + (account.total ?? 0));
 
     List<FlSpot> spots = [];


### PR DESCRIPTION
## 🎯 Description

Accounts have a "Counts for the net worth" toggle, but this setting was being ignored when calculating the available liquidity shown in the Graphs page.

The monthly transaction queries already correctly filtered by `countNetWorth = 1`, but the initial balance (summed from all accounts) did not apply the same filter causing accounts excluded from net worth to still inflate the displayed total.

Closes: N/A

## 📱 Changes

- [x] Filter accounts by `countNetWorth` when computing the starting balance in `StatisticsProvider`

## 🧪 Testing Instructions

### Behaviour
1. Create (or edit) an account and set "Counts for the net worth" to **off**
2. Navigate to the Graphs page
3. Verify that the net worth graph and total **do not** include the balance of the excluded account
4. Re-enable the toggle on the same account
5. Verify that the net worth graph and total **do** include that account's balance again


## 🔍 Checklist for reviewers
- [X] Code is formatted correctly
- [X] Tests are passing
- [X] New tests are added (if needed)
- [X] Style matches the figma/designer requests
- Tested on:
    - [X] iOS
    - [X] Android