### PR TITLE
Feat: Category and Account deletion

### DIFF
--- a/lib/model/bank_account.dart
+++ b/lib/model/bank_account.dart
@@ -1,3 +1,4 @@
+import '../ui/extensions.dart';
 import 'base_entity.dart';
 
 const String bankAccountTable = 'bankAccount';
@@ -15,6 +16,7 @@ class BankAccountFields extends BaseEntityFields {
   static String order = 'position';
   static String createdAt = BaseEntityFields.getCreatedAt;
   static String updatedAt = BaseEntityFields.getUpdatedAt;
+  static String deletedAt = BaseEntityFields.getDeletedAt;
 
   static final List<String> allFields = [
     BaseEntityFields.id,
@@ -28,6 +30,7 @@ class BankAccountFields extends BaseEntityFields {
     order,
     BaseEntityFields.createdAt,
     BaseEntityFields.updatedAt,
+    BaseEntityFields.deletedAt,
   ];
 }
 
@@ -55,6 +58,7 @@ class BankAccount extends BaseEntity {
     this.total,
     super.createdAt,
     super.updatedAt,
+    super.deletedAt,
   });
 
   BankAccount copy({
@@ -69,6 +73,7 @@ class BankAccount extends BaseEntity {
     int? order,
     DateTime? createdAt,
     DateTime? updatedAt,
+    DateTime? deletedAt,
   }) => BankAccount(
     id: id ?? this.id,
     name: name ?? this.name,
@@ -81,6 +86,7 @@ class BankAccount extends BaseEntity {
     order: order ?? this.order,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
+    deletedAt: deletedAt ?? this.deletedAt,
     total: total,
   );
 
@@ -97,21 +103,25 @@ class BankAccount extends BaseEntity {
     total: json[BankAccountFields.total] as num?,
     createdAt: DateTime.parse(json[BaseEntityFields.createdAt] as String),
     updatedAt: DateTime.parse(json[BaseEntityFields.updatedAt] as String),
+    deletedAt: json[BaseEntityFields.deletedAt] != null
+        ? DateTime.parse(json[BaseEntityFields.deletedAt] as String)
+        : null,
   );
 
-  Map<String, Object?> toJson({bool update = false}) => {
+  Map<String, Object?> toJson({bool update = false, bool delete = false}) => {
     BaseEntityFields.id: id,
     BankAccountFields.name: name,
     BankAccountFields.symbol: symbol,
     BankAccountFields.color: color,
-    BankAccountFields.startingValue: startingValue,
+    BankAccountFields.startingValue: startingValue.toCurrency().toNum(),
     BankAccountFields.active: active ? 1 : 0,
     BankAccountFields.countNetWorth: countNetWorth ? 1 : 0,
     BankAccountFields.mainAccount: mainAccount ? 1 : 0,
-    BankAccountFields.order: order,
-    BaseEntityFields.createdAt: update
+    BankAccountFields.order: delete ? 0 : order,
+    BaseEntityFields.createdAt: update || delete
         ? createdAt?.toIso8601String()
         : DateTime.now().toIso8601String(),
     BaseEntityFields.updatedAt: DateTime.now().toIso8601String(),
+    if (delete) BaseEntityFields.deletedAt: DateTime.now().toIso8601String(),
   };
 }

--- a/lib/model/bank_account.dart
+++ b/lib/model/bank_account.dart
@@ -114,9 +114,9 @@ class BankAccount extends BaseEntity {
     BankAccountFields.symbol: symbol,
     BankAccountFields.color: color,
     BankAccountFields.startingValue: startingValue.toCurrency().toNum(),
-    BankAccountFields.active: active ? 1 : 0,
-    BankAccountFields.countNetWorth: countNetWorth ? 1 : 0,
-    BankAccountFields.mainAccount: mainAccount ? 1 : 0,
+    BankAccountFields.active: active && !delete ? 1 : 0,
+    BankAccountFields.countNetWorth: countNetWorth && !delete ? 1 : 0,
+    BankAccountFields.mainAccount: mainAccount && !delete ? 1 : 0,
     BankAccountFields.order: delete ? 0 : order,
     BaseEntityFields.createdAt: update || delete
         ? createdAt?.toIso8601String()

--- a/lib/model/base_entity.dart
+++ b/lib/model/base_entity.dart
@@ -2,6 +2,7 @@ abstract class BaseEntityFields {
   static String id = 'id';
   static String createdAt = 'createdAt';
   static String updatedAt = 'updatedAt';
+  static String deletedAt = 'deletedAt';
 
   static String get getId {
     return id;
@@ -14,12 +15,17 @@ abstract class BaseEntityFields {
   static String get getUpdatedAt {
     return updatedAt;
   }
+
+  static String get getDeletedAt {
+    return deletedAt;
+  }
 }
 
 abstract class BaseEntity {
   final int? id;
   final DateTime? createdAt;
   final DateTime? updatedAt;
+  final DateTime? deletedAt;
 
-  const BaseEntity({this.id, this.createdAt, this.updatedAt});
+  const BaseEntity({this.id, this.createdAt, this.updatedAt, this.deletedAt});
 }

--- a/lib/model/category_transaction.dart
+++ b/lib/model/category_transaction.dart
@@ -14,6 +14,7 @@ class CategoryTransactionFields extends BaseEntityFields {
   static String order = 'position';
   static String createdAt = BaseEntityFields.getCreatedAt;
   static String updatedAt = BaseEntityFields.getUpdatedAt;
+  static String deletedAt = BaseEntityFields.getDeletedAt;
 
   static final List<String> allFields = [
     BaseEntityFields.id,
@@ -26,6 +27,7 @@ class CategoryTransactionFields extends BaseEntityFields {
     order,
     BaseEntityFields.createdAt,
     BaseEntityFields.updatedAt,
+    BaseEntityFields.deletedAt,
   ];
 }
 
@@ -75,6 +77,7 @@ class CategoryTransaction extends BaseEntity {
     required this.order,
     super.createdAt,
     super.updatedAt,
+    super.deletedAt,
   });
 
   CategoryTransaction copy({
@@ -88,6 +91,7 @@ class CategoryTransaction extends BaseEntity {
     int? order,
     DateTime? createdAt,
     DateTime? updatedAt,
+    DateTime? deletedAt,
   }) => CategoryTransaction(
     id: id ?? this.id,
     name: name ?? this.name,
@@ -99,6 +103,7 @@ class CategoryTransaction extends BaseEntity {
     order: order ?? this.order,
     createdAt: createdAt ?? this.createdAt,
     updatedAt: updatedAt ?? this.updatedAt,
+    deletedAt: deletedAt ?? this.deletedAt,
   );
 
   static CategoryTransaction fromJson(Map<String, Object?> json) =>
@@ -115,9 +120,12 @@ class CategoryTransaction extends BaseEntity {
         order: json[CategoryTransactionFields.order] as int,
         createdAt: DateTime.parse(json[BaseEntityFields.createdAt] as String),
         updatedAt: DateTime.parse(json[BaseEntityFields.updatedAt] as String),
+        deletedAt: json[BaseEntityFields.deletedAt] != null
+            ? DateTime.parse(json[BaseEntityFields.deletedAt] as String)
+            : null,
       );
 
-  Map<String, Object?> toJson({bool update = false}) => {
+  Map<String, Object?> toJson({bool update = false, bool delete = false}) => {
     BaseEntityFields.id: id,
     CategoryTransactionFields.name: name,
     CategoryTransactionFields.type: type.code,
@@ -125,10 +133,11 @@ class CategoryTransaction extends BaseEntity {
     CategoryTransactionFields.color: color,
     CategoryTransactionFields.note: note,
     CategoryTransactionFields.parent: parent,
-    CategoryTransactionFields.order: order,
-    BaseEntityFields.createdAt: update
+    CategoryTransactionFields.order: delete ? 0 : order,
+    BaseEntityFields.createdAt: update || delete
         ? createdAt?.toIso8601String()
         : DateTime.now().toIso8601String(),
     BaseEntityFields.updatedAt: DateTime.now().toIso8601String(),
+    if (delete) BaseEntityFields.deletedAt: DateTime.now().toIso8601String(),
   };
 }

--- a/lib/pages/accounts/account_list_page.dart
+++ b/lib/pages/accounts/account_list_page.dart
@@ -18,7 +18,7 @@ class AccountListPage extends ConsumerStatefulWidget {
 class _AccountListPage extends ConsumerState<AccountListPage> {
   @override
   Widget build(BuildContext context) {
-    final accountsList = ref.watch(accountsProvider);
+    final accountsList = ref.watch(activeAccountsProvider);
     ref.listen(selectedAccountProvider, (_, _) {});
     return Scaffold(
       appBar: AppBar(

--- a/lib/pages/accounts/widgets/confirm_account_deletion_dialog.dart
+++ b/lib/pages/accounts/widgets/confirm_account_deletion_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 
+import '../../../ui/device.dart';
 import '../../../ui/widgets/native_alert_dialog.dart';
 import '../../../model/bank_account.dart';
 
@@ -17,8 +18,20 @@ class ConfirmAccountDeletionDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AdaptiveDialog(
       title: const Text('Delete account'),
-      content: Text(
-        'Are you sure you want to delete the account named "${account.name}"?\n\nThis action cannot be undone.',
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: Sizes.md,
+        children: [
+          Text(
+            'Are you sure you want to delete the account named "${account.name}"?',
+          ),
+          const Text(
+            'All recurring transactions linked to this account will be stopped.',
+          ),
+          const SizedBox(height: Sizes.md),
+          const Text('This action cannot be undone.'),
+        ],
       ),
       actions: [
         AdaptiveDialogAction(

--- a/lib/pages/accounts/widgets/confirm_account_deletion_dialog.dart
+++ b/lib/pages/accounts/widgets/confirm_account_deletion_dialog.dart
@@ -27,7 +27,7 @@ class ConfirmAccountDeletionDialog extends StatelessWidget {
             'Are you sure you want to delete the account named "${account.name}"?',
           ),
           const Text(
-            'All recurring transactions linked to this account will be stopped.',
+            'All recurring transactions linked to this account will be deleted.',
           ),
           const SizedBox(height: Sizes.md),
           const Text('This action cannot be undone.'),

--- a/lib/pages/categories/category_list_page.dart
+++ b/lib/pages/categories/category_list_page.dart
@@ -13,7 +13,7 @@ class CategoryList extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final categorysList = ref.watch(allParentCategoriesProvider);
+    final categoriesList = ref.watch(allParentCategoriesProvider);
     ref.listen(selectedCategoryProvider, (_, _) {});
     return Scaffold(
       appBar: AppBar(
@@ -38,11 +38,11 @@ class CategoryList extends ConsumerWidget {
         physics: const BouncingScrollPhysics(),
         child: Column(
           children: [
-            categorysList.when(
-              data: (categorys) => ReorderableListView.builder(
+            categoriesList.when(
+              data: (categories) => ReorderableListView.builder(
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
-                itemCount: categorys.length,
+                itemCount: categories.length,
                 onReorder: (oldIndex, newIndex) {
                   ref
                       .read(categoriesProvider.notifier)
@@ -56,7 +56,7 @@ class CategoryList extends ConsumerWidget {
                   );
                 },
                 itemBuilder: (context, i) {
-                  CategoryTransaction category = categorys[i];
+                  CategoryTransaction category = categories[i];
                   return Container(
                     key: ValueKey(category.id),
                     margin: const EdgeInsets.only(bottom: Sizes.lg),

--- a/lib/pages/categories/create_edit_category_page.dart
+++ b/lib/pages/categories/create_edit_category_page.dart
@@ -244,7 +244,7 @@ class _CreateEditCategoryPage extends ConsumerState<CreateEditCategoryPage> {
                 child: TextButton.icon(
                   onPressed: () => ref
                       .read(categoriesProvider.notifier)
-                      .removeCategory(selectedCategory.id!)
+                      .removeCategory(selectedCategory)
                       .whenComplete(() {
                         if (context.mounted) {
                           Navigator.of(context).pop();

--- a/lib/pages/categories/create_edit_category_page.dart
+++ b/lib/pages/categories/create_edit_category_page.dart
@@ -9,6 +9,7 @@ import '../../../providers/transactions_provider.dart';
 import '../../../ui/device.dart';
 import '../../../ui/extensions.dart';
 import 'widgets/category_icon_color_selector.dart';
+import 'widgets/confirm_category_deletion_dialog.dart';
 import 'widgets/subcategories_list.dart';
 
 class CreateEditCategoryPage extends ConsumerStatefulWidget {
@@ -242,14 +243,27 @@ class _CreateEditCategoryPage extends ConsumerState<CreateEditCategoryPage> {
                 width: double.infinity,
                 padding: const EdgeInsets.all(Sizes.lg),
                 child: TextButton.icon(
-                  onPressed: () => ref
-                      .read(categoriesProvider.notifier)
-                      .removeCategory(selectedCategory)
-                      .whenComplete(() {
-                        if (context.mounted) {
-                          Navigator.of(context).pop();
-                        }
-                      }),
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      builder: (context) {
+                        return ConfirmCategoryDeletionDialog(
+                          category: selectedCategory,
+                          onPressed: () => ref
+                              .read(categoriesProvider.notifier)
+                              .removeCategory(selectedCategory)
+                              .whenComplete(() {
+                                if (context.mounted) {
+                                  Navigator.popUntil(
+                                    context,
+                                    ModalRoute.withName('/category-list'),
+                                  );
+                                }
+                              }),
+                        );
+                      },
+                    );
+                  },
                   style: TextButton.styleFrom(
                     side: const BorderSide(color: red, width: 1),
                   ),

--- a/lib/pages/categories/create_edit_subcategory_page.dart
+++ b/lib/pages/categories/create_edit_subcategory_page.dart
@@ -166,7 +166,7 @@ class _CreateEditSubcategoryPage
                 child: TextButton.icon(
                   onPressed: () => ref
                       .read(categoriesProvider.notifier)
-                      .removeCategory(selectedSubcategory.id!)
+                      .removeCategory(selectedSubcategory)
                       .whenComplete(() {
                         if (context.mounted) {
                           Navigator.of(context).pop();

--- a/lib/pages/categories/widgets/confirm_category_deletion_dialog.dart
+++ b/lib/pages/categories/widgets/confirm_category_deletion_dialog.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import '../../../model/category_transaction.dart';
+import '../../../ui/device.dart';
+import '../../../ui/widgets/native_alert_dialog.dart';
+
+class ConfirmCategoryDeletionDialog extends StatelessWidget {
+  final CategoryTransaction category;
+  final VoidCallback onPressed;
+
+  const ConfirmCategoryDeletionDialog({
+    required this.category,
+    required this.onPressed,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AdaptiveDialog(
+      title: const Text('Delete category'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        spacing: Sizes.md,
+        children: [
+          Text(
+            'Are you sure you want to delete the category named "${category.name}"?',
+          ),
+          const Text(
+            'All recurring transactions linked to this category will be stopped.',
+          ),
+          const SizedBox(height: Sizes.md),
+          const Text('This action cannot be undone.'),
+        ],
+      ),
+      actions: [
+        AdaptiveDialogAction(
+          child: const Text('Cancel'),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+        AdaptiveDialogAction(
+          child: const Text('Delete'),
+          isDestructiveAction: true,
+          onPressed: onPressed,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/pages/categories/widgets/confirm_category_deletion_dialog.dart
+++ b/lib/pages/categories/widgets/confirm_category_deletion_dialog.dart
@@ -27,7 +27,7 @@ class ConfirmCategoryDeletionDialog extends StatelessWidget {
             'Are you sure you want to delete the category named "${category.name}"?',
           ),
           const Text(
-            'All recurring transactions linked to this category will be stopped.',
+            'All recurring transactions and budgets linked to this category will be deleted.',
           ),
           const SizedBox(height: Sizes.md),
           const Text('This action cannot be undone.'),

--- a/lib/pages/dashboard/widgets/account_section.dart
+++ b/lib/pages/dashboard/widgets/account_section.dart
@@ -14,7 +14,7 @@ class AccountSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final accountList = ref.watch(accountsProvider);
+    final accountList = ref.watch(activeAccountsProvider);
     final isDarkMode = ref.watch(appThemeStateProvider).isDarkModeEnabled;
     return SizedBox(
       height: 80.0,

--- a/lib/pages/graphs/widgets/accounts/accounts_card.dart
+++ b/lib/pages/graphs/widgets/accounts/accounts_card.dart
@@ -15,7 +15,7 @@ class AccountsCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final accountList = ref.watch(accountsProvider);
+    final accountList = ref.watch(activeAccountsProvider);
     final currencyState = ref.watch(currencyStateProvider);
 
     return Column(

--- a/lib/pages/planning/widget/budget_card.dart
+++ b/lib/pages/planning/widget/budget_card.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -22,7 +23,7 @@ class BudgetCard extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final budgetsAsync = ref.watch(budgetsProvider);
     final transactionsAsync = ref.watch(monthlyTransactionsProvider);
-    final categories = ref.watch(allParentCategoriesProvider).value ?? [];
+    final categoriesAsync = ref.watch(allParentCategoriesProvider);
     final currencyState = ref.watch(currencyStateProvider);
 
     return DefaultContainer(
@@ -30,93 +31,105 @@ class BudgetCard extends ConsumerWidget {
       child: budgetsAsync.when(
         data: (budgets) {
           return budgets.isNotEmpty
-              ? transactionsAsync.when(
-                  data: (transactions) {
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          "Composition",
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                        BudgetPieChart(
-                          budgets: budgets,
-                          categories: categories,
-                        ),
-                        Text(
-                          "Progress",
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                        const SizedBox(height: Sizes.sm),
-                        ListView.separated(
-                          shrinkWrap: true,
-                          physics: const NeverScrollableScrollPhysics(),
-                          itemCount: budgets.length,
-                          itemBuilder: (BuildContext context, int index) {
-                            final budget = budgets[index];
-                            num spent = num.parse(
-                              transactions
-                                  .where(
-                                    (t) =>
-                                        t.idCategory == budget.idCategory ||
-                                        t.categoryParent == budget.idCategory,
-                                  )
-                                  .fold(0.0, (sum, t) => sum + t.amount)
-                                  .toCurrency(),
-                            );
-                            CategoryTransaction category = categories
-                                .firstWhere(
-                                  (cat) => cat.id == budget.idCategory,
+              ? categoriesAsync.when(
+                  data: (categories) {
+                    return transactionsAsync.when(
+                      data: (transactions) {
+                        return Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              "Composition",
+                              style: Theme.of(context).textTheme.titleLarge,
+                            ),
+                            BudgetPieChart(
+                              budgets: budgets,
+                              categories: categories,
+                            ),
+                            Text(
+                              "Progress",
+                              style: Theme.of(context).textTheme.titleLarge,
+                            ),
+                            const SizedBox(height: Sizes.sm),
+                            ListView.separated(
+                              shrinkWrap: true,
+                              physics: const NeverScrollableScrollPhysics(),
+                              itemCount: budgets.length,
+                              itemBuilder: (BuildContext context, int index) {
+                                final budget = budgets[index];
+                                num spent = num.parse(
+                                  transactions
+                                      .where(
+                                        (t) =>
+                                            t.idCategory == budget.idCategory ||
+                                            t.categoryParent ==
+                                                budget.idCategory,
+                                      )
+                                      .fold(0.0, (sum, t) => sum + t.amount)
+                                      .toCurrency(),
                                 );
-                            return Column(
-                              children: [
-                                Row(
+                                CategoryTransaction? category = categories
+                                    .firstWhereOrNull(
+                                      (cat) => cat.id == budget.idCategory,
+                                    );
+
+                                if (category == null) return const SizedBox();
+
+                                return Column(
                                   children: [
-                                    Text(
-                                      budget.name!,
-                                      style: const TextStyle(
-                                        fontWeight: FontWeight.normal,
-                                      ),
+                                    Row(
+                                      children: [
+                                        Text(
+                                          budget.name!,
+                                          style: const TextStyle(
+                                            fontWeight: FontWeight.normal,
+                                          ),
+                                        ),
+                                        const Spacer(),
+                                        if (spent >= (budget.amountLimit * 0.9))
+                                          const Icon(
+                                            Icons.error_outline,
+                                            color: Colors.red,
+                                          ),
+                                        Text(
+                                          "$spent/${budget.amountLimit.toCurrency()}${currencyState.symbol}",
+                                          style: const TextStyle(
+                                            fontWeight: FontWeight.normal,
+                                          ),
+                                        ),
+                                      ],
                                     ),
-                                    const Spacer(),
-                                    if (spent >= (budget.amountLimit * 0.9))
-                                      const Icon(
-                                        Icons.error_outline,
-                                        color: Colors.red,
-                                      ),
-                                    Text(
-                                      "$spent/${budget.amountLimit.toCurrency()}${currencyState.symbol}",
-                                      style: const TextStyle(
-                                        fontWeight: FontWeight.normal,
-                                      ),
+                                    const SizedBox(height: Sizes.xs),
+                                    LinearProgressBar(
+                                      type: BarType.category,
+                                      colorIndex: category.color,
+                                      amount:
+                                          (spent == 0 ||
+                                              budget.amountLimit == 0)
+                                          ? 0
+                                          : spent,
+                                      total: budget.amountLimit,
                                     ),
                                   ],
-                                ),
-                                const SizedBox(height: Sizes.xs),
-                                LinearProgressBar(
-                                  type: BarType.category,
-                                  colorIndex: category.color,
-                                  amount:
-                                      (spent == 0 || budget.amountLimit == 0)
-                                      ? 0
-                                      : spent,
-                                  total: budget.amountLimit,
-                                ),
-                              ],
-                            );
-                          },
-                          separatorBuilder: (context, index) {
-                            return const SizedBox(height: Sizes.lg);
-                          },
-                        ),
-                      ],
+                                );
+                              },
+                              separatorBuilder: (context, index) {
+                                return const SizedBox(height: Sizes.lg);
+                              },
+                            ),
+                          ],
+                        );
+                      },
+                      loading: () =>
+                          const Center(child: CircularProgressIndicator()),
+                      error: (err, stack) {
+                        return Text('Error: $err');
+                      },
                     );
                   },
                   loading: () =>
                       const Center(child: CircularProgressIndicator()),
-                  error: (err, stack) {
-                    return Text('Error: $err');
-                  },
+                  error: (err, stack) => Text('Error: $err'),
                 )
               : Column(
                   children: [

--- a/lib/pages/planning/widget/budget_pie_chart.dart
+++ b/lib/pages/planning/widget/budget_pie_chart.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -20,21 +21,28 @@ class BudgetPieChart extends ConsumerWidget {
   final List<CategoryTransaction> categories;
 
   List<PieChartSectionData> showingSections(double totalBudget) {
-    return List.generate(budgets.length, (i) {
-      final Budget budget = budgets.elementAt(i);
-      final CategoryTransaction category = categories.firstWhere(
+    final List<PieChartSectionData> sections = [];
+
+    for (final budget in budgets) {
+      final category = categories.firstWhereOrNull(
         (cat) => cat.id == budget.idCategory,
       );
 
-      double value = (budget.amountLimit / totalBudget) * 100;
+      if (category == null) continue;
 
-      return PieChartSectionData(
-        color: categoryColorList[category.color],
-        value: value,
-        title: "",
-        radius: 20,
+      final value = (budget.amountLimit / totalBudget) * 100;
+
+      sections.add(
+        PieChartSectionData(
+          color: categoryColorList[category.color],
+          value: value,
+          title: "",
+          radius: 20,
+        ),
       );
-    });
+    }
+
+    return sections;
   }
 
   @override

--- a/lib/pages/planning/widget/recurring_payments_list.dart
+++ b/lib/pages/planning/widget/recurring_payments_list.dart
@@ -118,7 +118,7 @@ class RecurringPaymentSection extends ConsumerWidget {
           );
         },
         loading: () {
-          return const CircularProgressIndicator();
+          return const Center(child: CircularProgressIndicator());
         },
         error: (error, _) {
           return Text('Error: $error');

--- a/lib/pages/transactions/create_transaction/widgets/account_selector.dart
+++ b/lib/pages/transactions/create_transaction/widgets/account_selector.dart
@@ -26,7 +26,7 @@ class AccountSelector extends ConsumerStatefulWidget {
 class _AccountSelectorState extends ConsumerState<AccountSelector> {
   @override
   Widget build(BuildContext context) {
-    final accountsList = ref.watch(accountsProvider);
+    final accountsList = ref.watch(activeAccountsProvider);
     final fromAccount = ref.watch(selectedBankAccountProvider);
     final toAccount = ref.watch(bankAccountTransferProvider);
 

--- a/lib/providers/accounts_provider.dart
+++ b/lib/providers/accounts_provider.dart
@@ -5,6 +5,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 import '../model/bank_account.dart';
 import '../model/transaction.dart';
 import '../services/database/repositories/account_repository.dart';
+import '../services/database/repositories/recurring_transactions_repository.dart';
 import 'dashboard_provider.dart';
 import 'recurring_transactions_provider.dart';
 import 'transactions_provider.dart';
@@ -220,8 +221,16 @@ class Accounts extends _$Accounts {
   Future<void> removeAccount(BankAccount account) async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
+      // delete recurring transactions tied to this account
+      if (account.id != null) {
+        await ref
+            .read(recurringTransactionRepositoryProvider)
+            .deleteByAccount(account.id!);
+      }
+
       await ref.read(accountRepositoryProvider).deleteById(account);
       if (account.mainAccount) ref.invalidate(mainAccountProvider);
+      ref.invalidate(recurringTransactionsProvider);
       return _getAccounts();
     });
   }

--- a/lib/providers/budgets_provider.dart
+++ b/lib/providers/budgets_provider.dart
@@ -20,6 +20,7 @@ class Budgets extends _$Budgets {
 
   Future<List<Budget>> _getBudgets() async {
     final budgets = await ref.read(budgetRepositoryProvider).selectAllActive();
+    ref.invalidate(monthlyBudgetsStatsProvider);
     return budgets;
   }
 

--- a/lib/providers/categories_provider.dart
+++ b/lib/providers/categories_provider.dart
@@ -136,10 +136,10 @@ class Categories extends _$Categories {
     });
   }
 
-  Future<void> removeCategory(int categoryId) async {
+  Future<void> removeCategory(CategoryTransaction category) async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
-      await ref.read(categoryRepositoryProvider).deleteById(categoryId);
+      await ref.read(categoryRepositoryProvider).deleteById(category);
       ref.invalidate(selectedSubcategoryProvider);
       ref.invalidate(categoryMapProvider);
       ref.invalidate(
@@ -176,14 +176,18 @@ class Categories extends _$Categories {
 
 @Riverpod(keepAlive: true)
 Future<List<CategoryTransaction>> allParentCategories(Ref ref) async {
-  final categories =
-      ref
-          .watch(categoriesProvider)
-          .value
-          ?.where((category) => category.parent == null)
-          .toList() ??
-      [];
-  return categories;
+  final categories = ref.watch(categoriesProvider).value ?? [];
+  return categories
+      .where(
+        (category) => category.parent == null && category.deletedAt == null,
+      )
+      .toList();
+}
+
+@Riverpod(keepAlive: true)
+Future<List<CategoryTransaction>> activeCategories(Ref ref) async {
+  final categories = ref.watch(categoriesProvider).value ?? [];
+  return categories.where((category) => category.deletedAt == null).toList();
 }
 
 @Riverpod(keepAlive: true)
@@ -235,9 +239,9 @@ Future<Map<CategoryTransaction, double>> categoryMap(Ref ref) async {
 
   Map<CategoryTransaction, double> categoriesMap = {};
 
-  final categories = await ref
-      .read(categoryRepositoryProvider)
-      .selectCategoriesByType(categoryType);
+  final categories = await ref.watch(
+    categoriesByTypeProvider(categoryType).future,
+  );
 
   final transactions = await ref
       .read(transactionsRepositoryProvider)

--- a/lib/providers/categories_provider.dart
+++ b/lib/providers/categories_provider.dart
@@ -185,12 +185,6 @@ Future<List<CategoryTransaction>> allParentCategories(Ref ref) async {
 }
 
 @Riverpod(keepAlive: true)
-Future<List<CategoryTransaction>> activeCategories(Ref ref) async {
-  final categories = ref.watch(categoriesProvider).value ?? [];
-  return categories.where((category) => category.deletedAt == null).toList();
-}
-
-@Riverpod(keepAlive: true)
 Future<List<CategoryTransaction>> categoriesByType(
   Ref ref,
   CategoryTransactionType? type, {

--- a/lib/providers/categories_provider.dart
+++ b/lib/providers/categories_provider.dart
@@ -4,6 +4,10 @@ import '../model/category_transaction.dart';
 import '../model/transaction.dart';
 import '../services/database/repositories/category_repository.dart';
 import '../services/database/repositories/transactions_repository.dart';
+import '../services/database/repositories/budget_repository.dart';
+import '../services/database/repositories/recurring_transactions_repository.dart';
+import 'budgets_provider.dart';
+import 'recurring_transactions_provider.dart';
 import 'transactions_provider.dart';
 
 part 'categories_provider.g.dart';
@@ -139,12 +143,37 @@ class Categories extends _$Categories {
   Future<void> removeCategory(CategoryTransaction category) async {
     state = const AsyncLoading();
     state = await AsyncValue.guard(() async {
+      // delete budgets and recurring transactions tied to this category and its subcategories
+      final cid = category.id;
+      if (cid != null) {
+        await ref.read(budgetRepositoryProvider).deleteByCategory(cid);
+        await ref
+            .read(recurringTransactionRepositoryProvider)
+            .deleteByCategory(cid);
+
+        // delete for direct subcategories as well
+        final subs = await ref
+            .read(categoryRepositoryProvider)
+            .selectSubCategory(cid);
+        for (var sub in subs) {
+          if (sub.id != null) {
+            await ref.read(budgetRepositoryProvider).deleteByCategory(sub.id!);
+            await ref
+                .read(recurringTransactionRepositoryProvider)
+                .deleteByCategory(sub.id!);
+          }
+        }
+      }
+
       await ref.read(categoryRepositoryProvider).deleteById(category);
       ref.invalidate(selectedSubcategoryProvider);
       ref.invalidate(categoryMapProvider);
       ref.invalidate(
         subcategoriesProvider(ref.read(selectedCategoryProvider)!.id!),
       );
+      ref.invalidate(recurringTransactionsProvider);
+      ref.invalidate(budgetsProvider);
+      ref.invalidate(monthlyBudgetsStatsProvider);
       return _getCategories();
     });
   }

--- a/lib/providers/categories_provider.dart
+++ b/lib/providers/categories_provider.dart
@@ -166,14 +166,15 @@ class Categories extends _$Categories {
       }
 
       await ref.read(categoryRepositoryProvider).deleteById(category);
-      ref.invalidate(selectedSubcategoryProvider);
-      ref.invalidate(categoryMapProvider);
-      ref.invalidate(
-        subcategoriesProvider(ref.read(selectedCategoryProvider)!.id!),
-      );
       ref.invalidate(recurringTransactionsProvider);
       ref.invalidate(budgetsProvider);
       ref.invalidate(monthlyBudgetsStatsProvider);
+      ref.invalidate(selectedSubcategoryProvider);
+      ref.invalidate(categoryMapProvider);
+      ref.invalidate(categoriesByTypeProvider(category.type));
+      ref.invalidate(
+        subcategoriesProvider(ref.read(selectedCategoryProvider)!.id!),
+      );
       return _getCategories();
     });
   }

--- a/lib/services/database/migrations/0007_add_deleted_at.dart
+++ b/lib/services/database/migrations/0007_add_deleted_at.dart
@@ -1,0 +1,26 @@
+// ignore_for_file: file_names
+
+import 'package:sqflite/sqflite.dart';
+import '../../../model/bank_account.dart';
+import '../migration_base.dart';
+
+// Models
+import '/model/category_transaction.dart';
+
+class AddDeletedAt extends Migration {
+  AddDeletedAt()
+    : super(
+        version: 6,
+        description: 'Add deletedAt column to account and category tables',
+      );
+
+  @override
+  Future<void> up(Database db) async {
+    await db.execute(
+      'ALTER TABLE $bankAccountTable ADD COLUMN ${BankAccountFields.deletedAt} TEXT',
+    );
+    await db.execute(
+      'ALTER TABLE $categoryTransactionTable ADD COLUMN ${CategoryTransactionFields.deletedAt} TEXT',
+    );
+  }
+}

--- a/lib/services/database/migrations/0007_add_deleted_at.dart
+++ b/lib/services/database/migrations/0007_add_deleted_at.dart
@@ -10,7 +10,7 @@ import '/model/category_transaction.dart';
 class AddDeletedAt extends Migration {
   AddDeletedAt()
     : super(
-        version: 6,
+        version: 7,
         description: 'Add deletedAt column to account and category tables',
       );
 

--- a/lib/services/database/migrations/migration_registry.dart
+++ b/lib/services/database/migrations/migration_registry.dart
@@ -17,6 +17,7 @@ import '0003_recurring_transaction_type.dart';
 import '0004_add_category_order.dart';
 import '0005_add_account_order.dart';
 import '0006_migrate_icons_name.dart';
+import '0007_add_deleted_at.dart';
 
 import '../migration_base.dart';
 
@@ -34,6 +35,7 @@ List<Migration> getMigrations() {
     AddCategoryOrder(),
     AddAccountOrder(),
     MigrateIconsName(),
+    AddDeletedAt(),
   ];
 }
 

--- a/lib/services/database/repositories/account_repository.dart
+++ b/lib/services/database/repositories/account_repository.dart
@@ -75,7 +75,7 @@ class AccountRepository {
   Future<List<BankAccount>> selectAll({bool? active, bool? deleted}) async {
     final db = await _sossoldiDB.database;
 
-    String where = "";
+    String where = "1 = 1";
     if (active != null) {
       where += ' AND ${BankAccountFields.active} = ${active ? 1 : 0}';
     }

--- a/lib/services/database/repositories/budget_repository.dart
+++ b/lib/services/database/repositories/budget_repository.dart
@@ -29,7 +29,7 @@ class BudgetRepository {
     final exists = await checkIfExists(item);
     if (exists) {
       await db.rawQuery(
-        "UPDATE $budgetTable SET amountLimit = ${item.amountLimit} WHERE idCategory = ${item.idCategory}",
+        "UPDATE $budgetTable SET ${BudgetFields.amountLimit} = ${item.amountLimit} AND ${BudgetFields.active} = 1 WHERE idCategory = ${item.idCategory}",
       );
     } else {
       await db.insert(budgetTable, item.toJson());
@@ -84,7 +84,7 @@ class BudgetRepository {
     final db = await _sossoldiDB.database;
     final orderByASC = '${BudgetFields.createdAt} ASC';
     final result = await db.rawQuery(
-      'SELECT bt.*, ct.name FROM $budgetTable as bt LEFT JOIN $categoryTransactionTable as ct ON bt.${BudgetFields.idCategory} = ct.${CategoryTransactionFields.id} WHERE bt.active = 1 ORDER BY $orderByASC',
+      'SELECT bt.*, ct.name FROM $budgetTable as bt LEFT JOIN $categoryTransactionTable as ct ON bt.${BudgetFields.idCategory} = ct.${CategoryTransactionFields.id} WHERE bt.${BudgetFields.active} = 1 ORDER BY $orderByASC',
     );
     return result.map((json) => Budget.fromJson(json)).toList();
   }
@@ -92,7 +92,7 @@ class BudgetRepository {
   Future<List<BudgetStats>> selectMonthlyBudgetsStats() async {
     final db = await _sossoldiDB.database;
     var query =
-        "SELECT bt.*, SUM(t.amount) as spent FROM $budgetTable as bt  LEFT JOIN $categoryTransactionTable as ct ON bt.${BudgetFields.idCategory} = ct.${CategoryTransactionFields.id}  LEFT JOIN '$transactionTable' as t ON t.${TransactionFields.idCategory} = ct.${CategoryTransactionFields.id}  WHERE bt.active = 1 AND strftime('%m', t.date) = strftime('%m', 'now') AND strftime('%Y', t.date) = strftime('%Y', 'now')  GROUP BY bt.${BudgetFields.idCategory};";
+        "SELECT bt.*, SUM(t.${TransactionFields.amount}) as spent FROM $budgetTable as bt LEFT JOIN $categoryTransactionTable as ct ON bt.${BudgetFields.idCategory} = ct.${CategoryTransactionFields.id} LEFT JOIN '$transactionTable' as t ON t.${TransactionFields.idCategory} = ct.${CategoryTransactionFields.id} WHERE bt.${BudgetFields.active} = 1 AND strftime('%m', t.date) = strftime('%m', 'now') AND strftime('%Y', t.date) = strftime('%Y', 'now') GROUP BY bt.${BudgetFields.idCategory};";
     final result = await db.rawQuery(query);
 
     List<Budget> allBudgets = await selectAllActive();

--- a/lib/services/database/repositories/budget_repository.dart
+++ b/lib/services/database/repositories/budget_repository.dart
@@ -27,15 +27,20 @@ class BudgetRepository {
     final db = await _sossoldiDB.database;
 
     final exists = await checkIfExists(item);
+    int itemId = item.id ?? 0;
+
     if (exists) {
-      await db.rawQuery(
-        "UPDATE $budgetTable SET ${BudgetFields.amountLimit} = ${item.amountLimit} AND ${BudgetFields.active} = 1 WHERE idCategory = ${item.idCategory}",
+      await db.update(
+        budgetTable,
+        {BudgetFields.amountLimit: item.amountLimit, BudgetFields.active: 1},
+        where: '${BudgetFields.idCategory} = ?',
+        whereArgs: [item.idCategory],
       );
     } else {
-      await db.insert(budgetTable, item.toJson());
+      itemId = await db.insert(budgetTable, item.toJson());
     }
 
-    return item.copy(id: item.id);
+    return item.copy(id: itemId);
   }
 
   Future<bool> checkIfExists(Budget item) async {
@@ -43,7 +48,7 @@ class BudgetRepository {
 
     try {
       final exists = await db.rawQuery(
-        "SELECT * FROM $budgetTable WHERE ${item.idCategory} = idCategory",
+        "SELECT * FROM $budgetTable WHERE ${BudgetFields.idCategory} = ${item.idCategory}",
       );
       if (exists.isNotEmpty) {
         return true;

--- a/lib/services/database/repositories/category_repository.dart
+++ b/lib/services/database/repositories/category_repository.dart
@@ -97,6 +97,7 @@ class CategoryRepository {
     if (!includeSubcategories) {
       where += ' AND ${CategoryTransactionFields.parent} IS NULL';
     }
+    where += ' AND ${CategoryTransactionFields.deletedAt} IS NULL';
 
     final result = await db.query(
       categoryTransactionTable,
@@ -163,16 +164,38 @@ class CategoryRepository {
     );
   }
 
-  Future<int> deleteById(int id) async {
+  Future<void> deleteById(
+    CategoryTransaction item, {
+    bool isSub = false,
+  }) async {
     final db = await _sossoldiDB.database;
 
-    final rows = await db.delete(
+    await db.update(
       categoryTransactionTable,
+      item.toJson(delete: true),
       where: '${CategoryTransactionFields.id} = ?',
-      whereArgs: [id],
+      whereArgs: [item.id],
     );
-    await normalizeOrders();
-    return rows;
+
+    await db
+        .query(
+          categoryTransactionTable,
+          where:
+              '${CategoryTransactionFields.parent} = ? AND ${CategoryTransactionFields.deletedAt} IS NULL',
+          whereArgs: [item.id],
+        )
+        .then((subcategories) async {
+          for (final subcategory in subcategories) {
+            await deleteById(
+              CategoryTransaction.fromJson(subcategory),
+              isSub: true,
+            );
+          }
+        });
+
+    if (!isSub) {
+      await normalizeOrders();
+    }
   }
 
   Future<void> updateOrders(List<CategoryTransaction> items) async {
@@ -196,6 +219,7 @@ class CategoryRepository {
     final result = await db.query(
       categoryTransactionTable,
       columns: [CategoryTransactionFields.id],
+      where: '${CategoryTransactionFields.deletedAt} IS NULL',
       orderBy: orderByASC,
     );
 

--- a/lib/services/database/repositories/category_repository.dart
+++ b/lib/services/database/repositories/category_repository.dart
@@ -92,12 +92,12 @@ class CategoryRepository {
   }) async {
     final db = await _sossoldiDB.database;
 
-    String where = '${CategoryTransactionFields.type} = ?';
+    String where =
+        '${CategoryTransactionFields.type} = ? AND ${CategoryTransactionFields.deletedAt} IS NULL';
     List<dynamic> args = [type.code];
     if (!includeSubcategories) {
       where += ' AND ${CategoryTransactionFields.parent} IS NULL';
     }
-    where += ' AND ${CategoryTransactionFields.deletedAt} IS NULL';
 
     final result = await db.query(
       categoryTransactionTable,
@@ -130,7 +130,7 @@ class CategoryRepository {
           ORDER BY "${TransactionFields.date}" DESC
           LIMIT 100
         ) t ON t."${TransactionFields.idCategory}" = c."${CategoryTransactionFields.id}"
-        WHERE c."${CategoryTransactionFields.type}" = ?
+        WHERE c."${CategoryTransactionFields.type}" = ? AND c.${CategoryTransactionFields.deletedAt} IS NULL
         GROUP BY c."${CategoryTransactionFields.id}"
         ORDER BY COUNT(t."${TransactionFields.id}") DESC
         LIMIT 5

--- a/lib/services/database/repositories/category_repository.dart
+++ b/lib/services/database/repositories/category_repository.dart
@@ -66,7 +66,8 @@ class CategoryRepository {
 
     final result = await db.query(
       categoryTransactionTable,
-      where: '${CategoryTransactionFields.parent} IS NULL',
+      where:
+          '${CategoryTransactionFields.parent} IS NULL AND ${CategoryTransactionFields.deletedAt} IS NULL',
       orderBy: orderByASC,
     );
 
@@ -78,7 +79,8 @@ class CategoryRepository {
 
     final result = await db.query(
       categoryTransactionTable,
-      where: '${CategoryTransactionFields.parent} = ?',
+      where:
+          '${CategoryTransactionFields.parent} = ? AND ${CategoryTransactionFields.deletedAt} IS NULL',
       whereArgs: [categoryId],
       orderBy: orderByASC,
     );
@@ -164,10 +166,7 @@ class CategoryRepository {
     );
   }
 
-  Future<void> deleteById(
-    CategoryTransaction item, {
-    bool isSub = false,
-  }) async {
+  Future<void> deleteById(CategoryTransaction item) async {
     final db = await _sossoldiDB.database;
 
     await db.update(
@@ -177,23 +176,19 @@ class CategoryRepository {
       whereArgs: [item.id],
     );
 
-    await db
-        .query(
-          categoryTransactionTable,
-          where:
-              '${CategoryTransactionFields.parent} = ? AND ${CategoryTransactionFields.deletedAt} IS NULL',
-          whereArgs: [item.id],
-        )
-        .then((subcategories) async {
-          for (final subcategory in subcategories) {
-            await deleteById(
-              CategoryTransaction.fromJson(subcategory),
-              isSub: true,
-            );
-          }
-        });
-
-    if (!isSub) {
+    if (item.parent == null) {
+      await db
+          .query(
+            categoryTransactionTable,
+            where:
+                '${CategoryTransactionFields.parent} = ? AND ${CategoryTransactionFields.deletedAt} IS NULL',
+            whereArgs: [item.id],
+          )
+          .then((subcategories) async {
+            for (final subcategory in subcategories) {
+              await deleteById(CategoryTransaction.fromJson(subcategory));
+            }
+          });
       await normalizeOrders();
     }
   }

--- a/lib/services/database/repositories/recurring_transactions_repository.dart
+++ b/lib/services/database/repositories/recurring_transactions_repository.dart
@@ -96,6 +96,26 @@ class RecurringTransactionRepository {
     );
   }
 
+  Future<int> deleteByCategory(int id) async {
+    final db = await _sossoldiDB.database;
+
+    return await db.delete(
+      recurringTransactionTable,
+      where: '${RecurringTransactionFields.idCategory} = ?',
+      whereArgs: [id],
+    );
+  }
+
+  Future<int> deleteByAccount(int id) async {
+    final db = await _sossoldiDB.database;
+
+    return await db.delete(
+      recurringTransactionTable,
+      where: '${RecurringTransactionFields.idBankAccount} = ?',
+      whereArgs: [id],
+    );
+  }
+
   Future<void> checkRecurringTransactions() async {
     // get all recurring transactions active
     final transactions = await selectAllActive();

--- a/lib/services/database/sossoldi_database.dart
+++ b/lib/services/database/sossoldi_database.dart
@@ -240,7 +240,7 @@ class SossoldiDatabase {
     // Add fake budgets
     await _database?.execute('''
       INSERT INTO budget(idCategory, name, amountLimit, active, createdAt, updatedAt) VALUES
-        (13, 'Grocery', 900.00, 1, '${DateTime.now()}', '${DateTime.now()}'),
+        (13, 'Shopping', 900.00, 1, '${DateTime.now()}', '${DateTime.now()}'),
         (11, 'Home', 123.45, 0, '${DateTime.now()}', '${DateTime.now()}');
     ''');
 


### PR DESCRIPTION
## 🎯 Description

Handle categories and accounts deletion correctly. Add a deleted_at field on both tables.

Closes: #177 

## 📱 Changes

- [x] Add migration for deleted_at fields in categories and bank accounts tables
- [x] Implement soft delete, to avoid breaking transactions.

## 🧪 Testing Instructions

- Test deleting both categories and accounts, check if everything is still working.


## 🔍 Checklist for reviewers
- [x] Code is formatted correctly
- [x] Tests are passing
- [x] New tests are added (if needed)
- [x] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [x] Android
