### PR TITLE
fix(dashboard): fix budget section category colors and spending calcu…

### DIFF
--- a/lib/pages/dashboard/widgets/budgets_section.dart
+++ b/lib/pages/dashboard/widgets/budgets_section.dart
@@ -1,9 +1,14 @@
+import 'dart:math';
+
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../constants/constants.dart';
 
 import '../../../ui/widgets/budget_circular_indicator.dart';
 import '../../../providers/budgets_provider.dart';
+import '../../../providers/categories_provider.dart';
+import '../../../providers/transactions_provider.dart';
 import '../../../ui/device.dart';
 
 class BudgetsSection extends ConsumerWidget {
@@ -11,7 +16,10 @@ class BudgetsSection extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final budgetsAsync = ref.watch(monthlyBudgetsStatsProvider);
+    final budgetsAsync = ref.watch(budgetsProvider);
+    final transactionsAsync = ref.watch(monthlyTransactionsProvider);
+    final categoriesAsync = ref.watch(allParentCategoriesProvider);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       spacing: Sizes.lg,
@@ -52,32 +60,52 @@ class BudgetsSection extends ConsumerWidget {
                   ],
                 ),
               );
-            } else {
-              return SizedBox(
-                height: 150,
-                width: MediaQuery.of(context).size.width,
-                child: ListView.builder(
-                  scrollDirection: Axis.horizontal,
-                  itemCount: budgets.length,
-                  itemBuilder: (context, index) => Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: Sizes.md),
-                    child: BudgetCircularIndicator(
-                      title: budgets[index].name!,
-                      amount:
-                          budgets[index].amountLimit - budgets[index].spent > 0
-                          ? budgets[index].amountLimit - budgets[index].spent
-                          : 0,
-                      perc:
-                          budgets[index].spent / budgets[index].amountLimit > 1
-                          ? 1
-                          : budgets[index].spent / budgets[index].amountLimit,
-                      color:
-                          categoryColorList[index % categoryColorList.length],
-                    ),
-                  ),
-                ),
-              );
             }
+            return transactionsAsync.when(
+              data: (transactions) => categoriesAsync.when(
+                data: (categories) {
+                  return SizedBox(
+                    height: 150,
+                    width: MediaQuery.of(context).size.width,
+                    child: ListView.builder(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: budgets.length,
+                      itemBuilder: (context, index) {
+                        final budget = budgets[index];
+                        final category = categories.firstWhereOrNull(
+                          (cat) => cat.id == budget.idCategory,
+                        );
+                        if (category == null) return const SizedBox();
+                        final double spent = transactions
+                            .where(
+                              (t) =>
+                                  t.idCategory == budget.idCategory ||
+                                  t.categoryParent == budget.idCategory,
+                            )
+                            .fold(0.0, (sum, t) => sum + t.amount);
+                        return Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: Sizes.md,
+                          ),
+                          child: BudgetCircularIndicator(
+                            title: budget.name!,
+                            amount: max(0, budget.amountLimit - spent),
+                            perc: budget.amountLimit > 0
+                                ? min(1, spent / budget.amountLimit)
+                                : 0,
+                            color: categoryColorList[category.color],
+                          ),
+                        );
+                      },
+                    ),
+                  );
+                },
+                error: (err, stack) => Text('Error: $err'),
+                loading: () => const Center(child: CircularProgressIndicator()),
+              ),
+              error: (err, stack) => Text('Error: $err'),
+              loading: () => const Center(child: CircularProgressIndicator()),
+            );
           },
           error: (err, stack) => Text('Error: $err'),
           loading: () => const Center(child: CircularProgressIndicator()),


### PR DESCRIPTION
## 🎯 Description

The dashboard's budget section was displaying incorrect category colors and missing spending from child categories. This PR fixes both issues by replacing the pre-computed `monthlyBudgetsStatsProvider` with direct use of `budgetsProvider`, `monthlyTransactionsProvider`, and `allParentCategoriesProvider`, moving the spending calculation to the widget layer for more accurate and transparent logic.

Closes: N/A

## 📱 Changes

- [ ] Fix budget indicators showing wrong colors — now uses `category.color` index instead of cycling by list position
- [ ] Fix spending calculation to include transactions from child categories via `categoryParent`
- [ ] Remove `num.parse`/`toCurrency` round-trip in spending calculation
- [ ] Replace manual ternaries with `min`/`max` for `amount` and `perc`
- [ ] Add division-by-zero guard when `amountLimit` is `0`

## 🧪 Testing Instructions

### Behaviour
1. Open the app and navigate to the Dashboard
2. Ensure at least one budget exists with a category that has sub-categories
3. Verify that the budget circular indicators display the correct category color (matching the color set in the category settings)
4. Add transactions under both the parent category and a child category
5. Verify that the spending amount and progress arc on the indicator correctly reflect the sum of all matching transactions

## 📸 Screenshots / Screen Recordings (if applicable)

If your PR involves UI changes, please add screenshots or screen recordings here.

| Platform | Before | After |
|----------|--------|-------|
| Android  |        |       |
| iOS      |        |       |

## 🔍 Checklist for reviewers
- [ ] Code is formatted correctly
- [ ] Tests are passing
- [ ] New tests are added (if needed)
- [ ] Style matches the figma/designer requests
- Tested on:
    - [ ] iOS
    - [ ] Android