### PR TITLE
feat(banking): persist bank connections and manage consent lifecycle

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,13 @@ analyzer:
   exclude:
     - "**/*.g.dart"
     - "**/*.freezed.dart"
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
   errors:
     invalid_annotation_target: ignore
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_phoenix/flutter_phoenix.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:package_info_plus/package_info_plus.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:local_auth/local_auth.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
-import 'package:flutter_phoenix/flutter_phoenix.dart';
 
+import 'providers/banking_provider.dart';
 import 'providers/settings_provider.dart';
 import 'providers/theme_provider.dart';
 import 'routes/routes.dart';
@@ -101,6 +102,7 @@ class Launcher extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    ref.watch(bankingCallbackBootstrapProvider);
     final appThemeState = ref.watch(appThemeStateProvider);
     final bool isOnboardingCompleted = ref.watch(onBoardingCompletedProvider);
     return MaterialApp(

--- a/lib/model/bank_account.dart
+++ b/lib/model/bank_account.dart
@@ -17,6 +17,12 @@ class BankAccountFields extends BaseEntityFields {
   static String createdAt = BaseEntityFields.getCreatedAt;
   static String updatedAt = BaseEntityFields.getUpdatedAt;
   static String deletedAt = BaseEntityFields.getDeletedAt;
+  static String ebAccountUid = 'ebAccountUid';
+  static String ebConnectionId = 'ebConnectionId';
+  static String identificationHash = 'identificationHash';
+  static String identificationHashes = 'identificationHashes';
+  static String iban = 'iban';
+  static String lastSyncAt = 'lastSyncAt';
 
   static final List<String> allFields = [
     BaseEntityFields.id,
@@ -31,10 +37,18 @@ class BankAccountFields extends BaseEntityFields {
     BaseEntityFields.createdAt,
     BaseEntityFields.updatedAt,
     BaseEntityFields.deletedAt,
+    ebAccountUid,
+    ebConnectionId,
+    identificationHash,
+    identificationHashes,
+    iban,
+    lastSyncAt,
   ];
 }
 
 class BankAccount extends BaseEntity {
+  static const _unset = Object();
+
   final String name;
   final String symbol;
   final int color;
@@ -44,6 +58,12 @@ class BankAccount extends BaseEntity {
   final bool mainAccount;
   final int order;
   final num? total;
+  final String? ebAccountUid;
+  final int? ebConnectionId;
+  final String? identificationHash;
+  final String? identificationHashes;
+  final String? iban;
+  final DateTime? lastSyncAt;
 
   const BankAccount({
     super.id,
@@ -56,6 +76,12 @@ class BankAccount extends BaseEntity {
     required this.mainAccount,
     required this.order,
     this.total,
+    this.ebAccountUid,
+    this.ebConnectionId,
+    this.identificationHash,
+    this.identificationHashes,
+    this.iban,
+    this.lastSyncAt,
     super.createdAt,
     super.updatedAt,
     super.deletedAt,
@@ -74,6 +100,12 @@ class BankAccount extends BaseEntity {
     DateTime? createdAt,
     DateTime? updatedAt,
     DateTime? deletedAt,
+    Object? ebAccountUid = _unset,
+    Object? ebConnectionId = _unset,
+    Object? identificationHash = _unset,
+    Object? identificationHashes = _unset,
+    Object? iban = _unset,
+    Object? lastSyncAt = _unset,
   }) => BankAccount(
     id: id ?? this.id,
     name: name ?? this.name,
@@ -88,6 +120,22 @@ class BankAccount extends BaseEntity {
     updatedAt: updatedAt ?? this.updatedAt,
     deletedAt: deletedAt ?? this.deletedAt,
     total: total,
+    ebAccountUid: ebAccountUid == _unset
+        ? this.ebAccountUid
+        : ebAccountUid as String?,
+    ebConnectionId: ebConnectionId == _unset
+        ? this.ebConnectionId
+        : ebConnectionId as int?,
+    identificationHash: identificationHash == _unset
+        ? this.identificationHash
+        : identificationHash as String?,
+    identificationHashes: identificationHashes == _unset
+        ? this.identificationHashes
+        : identificationHashes as String?,
+    iban: iban == _unset ? this.iban : iban as String?,
+    lastSyncAt: lastSyncAt == _unset
+        ? this.lastSyncAt
+        : lastSyncAt as DateTime?,
   );
 
   static BankAccount fromJson(Map<String, Object?> json) => BankAccount(
@@ -106,6 +154,15 @@ class BankAccount extends BaseEntity {
     deletedAt: json[BaseEntityFields.deletedAt] != null
         ? DateTime.parse(json[BaseEntityFields.deletedAt] as String)
         : null,
+    ebAccountUid: json[BankAccountFields.ebAccountUid] as String?,
+    ebConnectionId: json[BankAccountFields.ebConnectionId] as int?,
+    identificationHash: json[BankAccountFields.identificationHash] as String?,
+    identificationHashes:
+        json[BankAccountFields.identificationHashes] as String?,
+    iban: json[BankAccountFields.iban] as String?,
+    lastSyncAt: json[BankAccountFields.lastSyncAt] == null
+        ? null
+        : DateTime.parse(json[BankAccountFields.lastSyncAt] as String).toUtc(),
   );
 
   Map<String, Object?> toJson({bool update = false, bool delete = false}) => {
@@ -123,5 +180,11 @@ class BankAccount extends BaseEntity {
         : DateTime.now().toIso8601String(),
     BaseEntityFields.updatedAt: DateTime.now().toIso8601String(),
     if (delete) BaseEntityFields.deletedAt: DateTime.now().toIso8601String(),
+    BankAccountFields.ebAccountUid: ebAccountUid,
+    BankAccountFields.ebConnectionId: ebConnectionId,
+    BankAccountFields.identificationHash: identificationHash,
+    BankAccountFields.identificationHashes: identificationHashes,
+    BankAccountFields.iban: iban,
+    BankAccountFields.lastSyncAt: lastSyncAt?.toUtc().toIso8601String(),
   };
 }

--- a/lib/model/bank_account_link.dart
+++ b/lib/model/bank_account_link.dart
@@ -1,0 +1,12 @@
+// dart format width=400
+
+import 'bank_account.dart';
+
+class BankAccountLink {
+  final String uid;
+  final Set<String> identificationHashes;
+  final String? iban;
+  final BankAccount? newAccount;
+
+  const BankAccountLink({required this.uid, required this.identificationHashes, this.iban, this.newAccount});
+}

--- a/lib/model/bank_connection.dart
+++ b/lib/model/bank_connection.dart
@@ -1,0 +1,144 @@
+// dart format width=400
+
+import 'base_entity.dart';
+
+const String bankConnectionTable = 'bankConnection';
+const String bankAccountIdentityTable = 'bankAccountIdentity';
+
+class BankConnectionFields extends BaseEntityFields {
+  static String id = BaseEntityFields.getId;
+  static String providerId = 'providerId';
+  static String institutionName = 'aspspName';
+  static String institutionCountry = 'aspspCountry';
+  static String applicationId = 'applicationId';
+  static String remoteConnectionId = 'sessionId';
+  static String pendingRemoteConnectionId = 'pendingSessionId';
+  static String pendingAuthorizationId = 'pendingAuthorizationId';
+  static String validUntil = 'validUntil';
+  static String pendingValidUntil = 'pendingValidUntil';
+  static String status = 'status';
+  static String psuType = 'psuType';
+  static String createdAt = BaseEntityFields.getCreatedAt;
+  static String updatedAt = BaseEntityFields.getUpdatedAt;
+
+  static final List<String> allFields = [id, providerId, institutionName, institutionCountry, applicationId, remoteConnectionId, pendingRemoteConnectionId, pendingAuthorizationId, validUntil, pendingValidUntil, status, psuType, createdAt, updatedAt];
+}
+
+class BankAccountIdentityFields {
+  static String connectionId = 'connectionId';
+  static String bankAccountId = 'bankAccountId';
+  static String identificationHash = 'identificationHash';
+}
+
+enum BankConnectionStatus {
+  authorizing,
+  awaitingImport,
+  active,
+  expired,
+  revoked,
+  reauthRequired,
+  revocationPending,
+  disconnected;
+
+  String get code => switch (this) {
+    BankConnectionStatus.authorizing => 'AUTHORIZING',
+    BankConnectionStatus.awaitingImport => 'AWAITING_IMPORT',
+    BankConnectionStatus.active => 'ACTIVE',
+    BankConnectionStatus.expired => 'EXPIRED',
+    BankConnectionStatus.revoked => 'REVOKED',
+    BankConnectionStatus.reauthRequired => 'REAUTH_REQUIRED',
+    BankConnectionStatus.revocationPending => 'REVOCATION_PENDING',
+    BankConnectionStatus.disconnected => 'DISCONNECTED',
+  };
+
+  static BankConnectionStatus fromJson(String code) => BankConnectionStatus.values.firstWhere((status) => status.code == code, orElse: () => throw FormatException('Unknown bank connection status: $code'));
+}
+
+class BankConnection extends BaseEntity {
+  static const _unset = Object();
+
+  final String providerId;
+  final String institutionName;
+  final String institutionCountry;
+  final String applicationId;
+  final String? remoteConnectionId;
+  final String? pendingRemoteConnectionId;
+  final String? pendingAuthorizationId;
+  final DateTime? validUntil;
+  final DateTime? pendingValidUntil;
+  final BankConnectionStatus status;
+  final String psuType;
+
+  const BankConnection({super.id, required this.providerId, required this.institutionName, required this.institutionCountry, required this.applicationId, this.remoteConnectionId, this.pendingRemoteConnectionId, this.pendingAuthorizationId, this.validUntil, this.pendingValidUntil, required this.status, this.psuType = 'personal', super.createdAt, super.updatedAt});
+
+  BankConnection copy({
+    int? id,
+    String? providerId,
+    String? institutionName,
+    String? institutionCountry,
+    String? applicationId,
+    Object? remoteConnectionId = _unset,
+    Object? pendingRemoteConnectionId = _unset,
+    Object? pendingAuthorizationId = _unset,
+    Object? validUntil = _unset,
+    Object? pendingValidUntil = _unset,
+    BankConnectionStatus? status,
+    String? psuType,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) => BankConnection(
+    id: id ?? this.id,
+    providerId: providerId ?? this.providerId,
+    institutionName: institutionName ?? this.institutionName,
+    institutionCountry: institutionCountry ?? this.institutionCountry,
+    applicationId: applicationId ?? this.applicationId,
+    remoteConnectionId: remoteConnectionId == _unset ? this.remoteConnectionId : remoteConnectionId as String?,
+    pendingRemoteConnectionId: pendingRemoteConnectionId == _unset ? this.pendingRemoteConnectionId : pendingRemoteConnectionId as String?,
+    pendingAuthorizationId: pendingAuthorizationId == _unset ? this.pendingAuthorizationId : pendingAuthorizationId as String?,
+    validUntil: validUntil == _unset ? this.validUntil : validUntil as DateTime?,
+    pendingValidUntil: pendingValidUntil == _unset ? this.pendingValidUntil : pendingValidUntil as DateTime?,
+    status: status ?? this.status,
+    psuType: psuType ?? this.psuType,
+    createdAt: createdAt ?? this.createdAt,
+    updatedAt: updatedAt ?? this.updatedAt,
+  );
+
+  static BankConnection fromJson(Map<String, Object?> json) => BankConnection(
+    id: json[BankConnectionFields.id] as int?,
+    providerId: json[BankConnectionFields.providerId] as String? ?? 'enable_banking',
+    institutionName: json[BankConnectionFields.institutionName] as String,
+    institutionCountry: json[BankConnectionFields.institutionCountry] as String,
+    applicationId: json[BankConnectionFields.applicationId] as String,
+    remoteConnectionId: json[BankConnectionFields.remoteConnectionId] as String?,
+    pendingRemoteConnectionId: json[BankConnectionFields.pendingRemoteConnectionId] as String?,
+    pendingAuthorizationId: json[BankConnectionFields.pendingAuthorizationId] as String?,
+    validUntil: _date(json[BankConnectionFields.validUntil]),
+    pendingValidUntil: _date(json[BankConnectionFields.pendingValidUntil]),
+    status: BankConnectionStatus.fromJson(json[BankConnectionFields.status] as String),
+    psuType: json[BankConnectionFields.psuType] as String? ?? 'personal',
+    createdAt: _date(json[BankConnectionFields.createdAt]),
+    updatedAt: _date(json[BankConnectionFields.updatedAt]),
+  );
+
+  Map<String, Object?> toJson({bool update = false, DateTime? clock}) {
+    final now = (clock ?? DateTime.now()).toUtc().toIso8601String();
+    return {
+      BankConnectionFields.id: id,
+      BankConnectionFields.providerId: providerId,
+      BankConnectionFields.institutionName: institutionName,
+      BankConnectionFields.institutionCountry: institutionCountry,
+      BankConnectionFields.applicationId: applicationId,
+      BankConnectionFields.remoteConnectionId: remoteConnectionId,
+      BankConnectionFields.pendingRemoteConnectionId: pendingRemoteConnectionId,
+      BankConnectionFields.pendingAuthorizationId: pendingAuthorizationId,
+      BankConnectionFields.validUntil: validUntil?.toUtc().toIso8601String(),
+      BankConnectionFields.pendingValidUntil: pendingValidUntil?.toUtc().toIso8601String(),
+      BankConnectionFields.status: status.code,
+      BankConnectionFields.psuType: psuType,
+      BankConnectionFields.createdAt: update ? createdAt?.toUtc().toIso8601String() : now,
+      BankConnectionFields.updatedAt: now,
+    };
+  }
+
+  static DateTime? _date(Object? value) => value == null ? null : DateTime.parse(value as String).toUtc();
+}

--- a/lib/providers/banking_provider.dart
+++ b/lib/providers/banking_provider.dart
@@ -1,13 +1,24 @@
 // dart format width=400
 
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../services/banking/banking_provider.dart';
-import '../services/banking/bank_institution_directory.dart' as domain;
-import '../services/banking/bank_consent_service.dart' as domain;
 import '../services/banking/bank_account_data_source.dart' as domain;
+import '../services/banking/bank_authorization_context.dart';
+import '../services/banking/bank_consent_service.dart' as domain;
+import '../services/banking/bank_institution_directory.dart' as domain;
+import '../services/banking/banking_provider.dart';
+import '../services/banking/enable_banking/enable_banking_config.dart';
 import '../services/banking/enable_banking/enable_banking_dependencies.dart';
+import '../services/banking/enable_banking/enable_banking_errors.dart';
 import '../services/banking/enable_banking/enable_banking_provider.dart';
+import '../services/banking/lifecycle/bank_authorization_callback.dart';
+import '../services/banking/lifecycle/bank_consent_lifecycle_service.dart';
+import '../services/banking/lifecycle/bank_deeplink_service.dart';
+import '../services/banking/lifecycle/banking_platform_support.dart';
+import '../services/banking/lifecycle/pending_bank_authorization_store.dart';
+import '../services/database/repositories/bank_connection_repository.dart';
 
 part 'banking_provider.g.dart';
 
@@ -22,3 +33,104 @@ domain.BankConsentService bankConsentService(Ref ref) => ref.watch(bankingServic
 
 @Riverpod(keepAlive: true)
 domain.BankAccountDataSource bankAccountDataSource(Ref ref) => ref.watch(bankingServiceProvider).accountData;
+
+@Riverpod(keepAlive: true)
+BankAuthorizationContextReader bankAuthorizationContextReader(Ref ref) {
+  final store = ref.watch(enableBankingCredentialsStoreProvider);
+  return () => readEnableBankingAuthorizationContext(store);
+}
+
+@Riverpod(keepAlive: true)
+PendingBankAuthorizationStore pendingBankAuthorizationStore(Ref ref) => const SecurePendingBankAuthorizationStore();
+
+@Riverpod(keepAlive: true)
+BankConsentLifecycleService bankConsentLifecycleService(Ref ref) => BankConsentLifecycleService(consent: ref.watch(bankConsentServiceProvider), institutions: ref.watch(bankInstitutionDirectoryProvider), readContext: ref.watch(bankAuthorizationContextReaderProvider), pendingStore: ref.watch(pendingBankAuthorizationStoreProvider), connections: ref.watch(bankConnectionRepositoryProvider));
+
+@Riverpod(keepAlive: true)
+BankDeeplinkService bankDeeplinkService(Ref ref) {
+  final service = BankDeeplinkService();
+  ref.onDispose(() => unawaited(service.dispose()));
+  return service;
+}
+
+class BankCallbackResultState {
+  final bool processing;
+  final int? connectionId;
+  final Object? error;
+
+  const BankCallbackResultState({this.processing = false, this.connectionId, this.error});
+}
+
+@Riverpod(keepAlive: true)
+class BankCallbackResult extends _$BankCallbackResult {
+  @override
+  BankCallbackResultState build() => const BankCallbackResultState();
+
+  Future<BankCallbackDisposition> handle(BankAuthorizationCallback callback) async {
+    state = const BankCallbackResultState(processing: true);
+    return ref
+        .read(bankConsentLifecycleServiceProvider)
+        .handleCallback(
+          callback,
+          onStaged: (staged) async {
+            state = BankCallbackResultState(connectionId: staged.connection.id);
+          },
+          onError: reportError,
+        );
+  }
+
+  Future<void> reportError(Object error) async {
+    state = BankCallbackResultState(error: error);
+  }
+}
+
+@Riverpod(keepAlive: true)
+Future<void> bankingCallbackBootstrap(Ref ref) async {
+  if (!BankingPlatformSupport.supportsCallback()) return;
+  await ref.read(bankConsentLifecycleServiceProvider).clearExpiredAuthorization();
+  await ref.watch(bankDeeplinkServiceProvider).start(ref.read(bankCallbackResultProvider.notifier).handle, onError: ref.read(bankCallbackResultProvider.notifier).reportError);
+}
+
+@Riverpod(keepAlive: true)
+class EnableBankingSettings extends _$EnableBankingSettings {
+  @override
+  Future<EnableBankingConfig?> build() async {
+    final store = ref.watch(enableBankingCredentialsStoreProvider);
+    return store.readConfig();
+  }
+
+  Future<bool> hasCredentials() async {
+    final store = ref.watch(enableBankingCredentialsStoreProvider);
+    return store.hasCredentials();
+  }
+
+  Future<void> save({required String appId, required String privateKeyPem, required EnableBankingConfig config}) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final store = ref.read(enableBankingCredentialsStoreProvider);
+      final previous = await store.readCredentials();
+      final saved = await ref.read(enableBankingCredentialsServiceProvider).saveVerifiedCredentials(appId: appId, privateKeyPem: privateKeyPem, redirectUri: config.redirectUri, defaultCountry: config.defaultCountry);
+      try {
+        await ref.read(bankConnectionRepositoryProvider).markOtherApplicationsReauthRequired(saved.appId, providerId: enableBankingId);
+      } catch (_) {
+        if (previous == null) {
+          await store.clear();
+        } else {
+          await store.saveCredentials(appId: previous.config.appId, privateKeyPem: previous.privateKeyPem, config: previous.config);
+        }
+        rethrow;
+      }
+      return saved;
+    });
+  }
+
+  Future<void> clear() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      final store = ref.read(enableBankingCredentialsStoreProvider);
+      await ref.read(bankConnectionRepositoryProvider).markAllReauthRequired(providerId: enableBankingId);
+      await store.clear();
+      return null;
+    });
+  }
+}

--- a/lib/services/banking/bank_authorization_context.dart
+++ b/lib/services/banking/bank_authorization_context.dart
@@ -1,0 +1,11 @@
+// dart format width=400
+
+class BankAuthorizationContext {
+  final String providerId;
+  final String applicationId;
+  final String redirectUri;
+
+  const BankAuthorizationContext({required this.providerId, required this.applicationId, required this.redirectUri});
+}
+
+typedef BankAuthorizationContextReader = Future<BankAuthorizationContext> Function();

--- a/lib/services/banking/banking_authorization.dart
+++ b/lib/services/banking/banking_authorization.dart
@@ -8,8 +8,9 @@ class BankingAuthorizationRequest {
   final DateTime validUntil;
   final String state;
   final String? language;
+  final Uri? redirectUri;
 
-  const BankingAuthorizationRequest({required this.institution, required this.validUntil, required this.state, this.customerType = BankingCustomerType.personal, this.language});
+  const BankingAuthorizationRequest({required this.institution, required this.validUntil, required this.state, this.customerType = BankingCustomerType.personal, this.language, this.redirectUri});
 }
 
 class BankingAuthorization {

--- a/lib/services/banking/banking_exception.dart
+++ b/lib/services/banking/banking_exception.dart
@@ -1,12 +1,16 @@
 // dart format width=400
 
-enum BankingFailure { authentication, forbidden, rateLimited, unavailable, invalidResponse, rejected }
+enum BankingFailure { authentication, forbidden, rateLimited, unavailable, invalidResponse, rejected, connectionExpired, connectionRevoked, connectionClosed, notFound }
 
 class BankingException implements Exception {
   final String providerId;
   final BankingFailure failure;
 
   const BankingException({required this.providerId, required this.failure});
+
+  bool get isRetryable => failure == BankingFailure.rateLimited || failure == BankingFailure.unavailable;
+
+  bool get confirmsMissingConnection => {BankingFailure.connectionRevoked, BankingFailure.connectionClosed, BankingFailure.notFound}.contains(failure);
 
   @override
   String toString() => 'BankingException($providerId, ${failure.name})';

--- a/lib/services/banking/enable_banking/enable_banking_api.dart
+++ b/lib/services/banking/enable_banking/enable_banking_api.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:async';
 
 import 'package:http/http.dart' as http;
 
@@ -33,14 +34,17 @@ class EnableBankingApi {
   final EnableBankingAuth _auth;
   final EnableBankingCredentialsStore _store;
   final http.Client _client;
+  final Duration _timeout;
 
   EnableBankingApi({
     required EnableBankingAuth auth,
     required EnableBankingCredentialsStore store,
     http.Client? client,
+    Duration timeout = const Duration(seconds: 30),
   }) : _auth = auth,
        _store = store,
-       _client = client ?? http.Client();
+       _client = client ?? http.Client(),
+       _timeout = timeout;
 
   Map<String, String> _headersForToken(String token) => {
     'Authorization': 'Bearer $token',
@@ -60,11 +64,72 @@ class EnableBankingApi {
     } catch (_) {
       body = null;
     }
+    final rawError = body?['error'];
+    final code = switch (rawError) {
+      String value => value,
+      Map<String, dynamic> value =>
+        _string(value['code']) ?? _string(value['error']),
+      _ => _string(body?['code']) ?? _string(body?['error_code']),
+    };
+    final rawMessage =
+        body?['message'] ??
+        (rawError is Map<String, dynamic> ? rawError['message'] : null) ??
+        body?['error_description'];
     throw EnableBankingException(
       statusCode: response.statusCode,
-      error: body?['error'] as String?,
-      message: body?['message'] as String?,
+      error: code,
+      message: rawMessage is String ? rawMessage : null,
+      kind: _failureKind(response.statusCode, code),
     );
+  }
+
+  String? _string(Object? value) => value is String ? value : null;
+
+  EnableBankingFailureKind _failureKind(int statusCode, String? code) {
+    switch (code?.toUpperCase()) {
+      case 'EXPIRED_SESSION':
+        return EnableBankingFailureKind.sessionExpired;
+      case 'REVOKED_SESSION':
+        return EnableBankingFailureKind.sessionRevoked;
+      case 'CLOSED_SESSION':
+        return EnableBankingFailureKind.sessionClosed;
+    }
+    return switch (statusCode) {
+      400 => EnableBankingFailureKind.invalidRequest,
+      401 || 403 => EnableBankingFailureKind.applicationAuthentication,
+      404 => EnableBankingFailureKind.notFound,
+      429 => EnableBankingFailureKind.rateLimited,
+      >= 500 => EnableBankingFailureKind.server,
+      _ => EnableBankingFailureKind.unknown,
+    };
+  }
+
+  Future<http.Response> _request(Future<http.Response> request) async {
+    try {
+      return await request.timeout(_timeout);
+    } on TimeoutException {
+      throw const EnableBankingException(
+        message: 'Enable Banking request timed out',
+        kind: EnableBankingFailureKind.timeout,
+      );
+    } on http.ClientException catch (error) {
+      throw EnableBankingException(
+        message: error.message,
+        kind: EnableBankingFailureKind.network,
+      );
+    }
+  }
+
+  Map<String, dynamic> _decodeObject(http.Response response) {
+    try {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    } catch (error) {
+      throw EnableBankingException(
+        statusCode: response.statusCode,
+        message: 'Malformed Enable Banking response: $error',
+        kind: EnableBankingFailureKind.invalidResponse,
+      );
+    }
   }
 
   Future<Map<String, dynamic>> _get(
@@ -74,16 +139,20 @@ class EnableBankingApi {
     final uri = Uri.parse('$_kBaseUrl$path').replace(
       queryParameters: query != null && query.isNotEmpty ? query : null,
     );
-    final response = await _client.get(uri, headers: await _headers());
+    final response = await _request(
+      _client.get(uri, headers: await _headers()),
+    );
     _check(response);
-    return jsonDecode(response.body) as Map<String, dynamic>;
+    return _decodeObject(response);
   }
 
   Future<Map<String, dynamic>> _getWithToken(String path, String token) async {
     final uri = Uri.parse('$_kBaseUrl$path');
-    final response = await _client.get(uri, headers: _headersForToken(token));
+    final response = await _request(
+      _client.get(uri, headers: _headersForToken(token)),
+    );
     _check(response);
-    return jsonDecode(response.body) as Map<String, dynamic>;
+    return _decodeObject(response);
   }
 
   Future<Map<String, dynamic>> _post(
@@ -91,18 +160,18 @@ class EnableBankingApi {
     Map<String, dynamic> body,
   ) async {
     final uri = Uri.parse('$_kBaseUrl$path');
-    final response = await _client.post(
-      uri,
-      headers: await _headers(),
-      body: jsonEncode(body),
+    final response = await _request(
+      _client.post(uri, headers: await _headers(), body: jsonEncode(body)),
     );
     _check(response);
-    return jsonDecode(response.body) as Map<String, dynamic>;
+    return _decodeObject(response);
   }
 
   Future<void> _delete(String path) async {
     final uri = Uri.parse('$_kBaseUrl$path');
-    final response = await _client.delete(uri, headers: await _headers());
+    final response = await _request(
+      _client.delete(uri, headers: await _headers()),
+    );
     _check(response);
   }
 
@@ -148,7 +217,9 @@ class EnableBankingApi {
     required DateTime validUntil,
     String psuType = 'personal',
     String? language,
+    String redirectUri = kEbRedirectUri,
   }) async {
+    validateEnableBankingRedirect(redirectUri);
     final json = await _post('/auth', {
       'access': {
         'valid_until': validUntil.toUtc().toIso8601String(),
@@ -157,7 +228,7 @@ class EnableBankingApi {
       },
       'aspsp': {'name': aspspName, 'country': aspspCountry},
       'state': state,
-      'redirect_url': kEbRedirectUri,
+      'redirect_url': redirectUri,
       'psu_type': psuType,
       'language': ?language,
     });

--- a/lib/services/banking/enable_banking/enable_banking_config.dart
+++ b/lib/services/banking/enable_banking/enable_banking_config.dart
@@ -1,7 +1,40 @@
 import 'enable_banking_exception.dart';
 
 /// Default OAuth callback URI registered with Enable Banking.
+///
+/// The custom scheme can be claimed by another local app and the HTTPS relay
+/// is an external availability dependency. OAuth state validation is therefore
+/// mandatory; relay or browser failures must remain observable and retryable.
 const String kEbRedirectUri = 'sossoldi://eb-callback';
+const String kEbRelayRedirectUri =
+    'https://rip-comm.github.io/sossoldi/enablebanking/eb-callback.html';
+
+Uri validateEnableBankingRedirect(
+  String value, {
+  Iterable<String>? registeredRedirects,
+}) {
+  final uri = Uri.tryParse(value);
+  final isAppCallback = value == kEbRedirectUri;
+  final isRelayCallback = value == kEbRelayRedirectUri;
+  if (uri == null ||
+      !uri.hasScheme ||
+      (!isAppCallback && !isRelayCallback) ||
+      uri.hasQuery ||
+      uri.hasFragment ||
+      uri.userInfo.isNotEmpty) {
+    throw const EnableBankingException(
+      message: 'Unsupported Enable Banking redirect URI',
+      kind: EnableBankingFailureKind.invalidRequest,
+    );
+  }
+  if (registeredRedirects != null && !registeredRedirects.contains(value)) {
+    throw const EnableBankingException(
+      message: 'Redirect URI is not registered for this application',
+      kind: EnableBankingFailureKind.invalidRequest,
+    );
+  }
+  return uri;
+}
 
 enum EnableBankingEnvironment {
   production,

--- a/lib/services/banking/enable_banking/enable_banking_consent_mapper.dart
+++ b/lib/services/banking/enable_banking/enable_banking_consent_mapper.dart
@@ -37,7 +37,7 @@ class EnableBankingConsentMapper {
 
   BankingConnection connection(EbSessionDetails value, BankingConnectionReference reference) {
     final identities = {
-      for (final account in value.accountsData) account.uid: {account.identificationHash, ...account.identificationHashes},
+      for (final account in value.accountsData) account.uid: {if (account.identificationHash != null) account.identificationHash!, ...account.identificationHashes},
     };
     return BankingConnection(
       reference: reference,

--- a/lib/services/banking/enable_banking/enable_banking_consent_service.dart
+++ b/lib/services/banking/enable_banking/enable_banking_consent_service.dart
@@ -6,6 +6,7 @@ import '../banking_connection.dart';
 import '../banking_exception.dart';
 import '../banking_reference.dart';
 import 'enable_banking_api.dart';
+import 'enable_banking_config.dart';
 import 'enable_banking_consent_mapper.dart';
 import 'enable_banking_errors.dart';
 import 'enable_banking_reference.dart';
@@ -20,7 +21,7 @@ class EnableBankingConsentService implements BankConsentService {
   Future<BankingAuthorization> startAuthorization(BankingAuthorizationRequest request) => withEnableBankingErrors(() async {
     checkEnableBankingReference(request.institution.providerId, request.institution.id);
     if (request.state.trim().isEmpty) throw const BankingException(providerId: enableBankingId, failure: BankingFailure.rejected);
-    return _mapper.authorization(await _api.startAuthorization(aspspName: request.institution.name, aspspCountry: request.institution.country, state: request.state, validUntil: request.validUntil, psuType: request.customerType.name, language: request.language));
+    return _mapper.authorization(await _api.startAuthorization(aspspName: request.institution.name, aspspCountry: request.institution.country, state: request.state, validUntil: request.validUntil, psuType: request.customerType.name, language: request.language, redirectUri: request.redirectUri?.toString() ?? kEbRedirectUri));
   });
 
   @override

--- a/lib/services/banking/enable_banking/enable_banking_credentials_service.dart
+++ b/lib/services/banking/enable_banking/enable_banking_credentials_service.dart
@@ -26,6 +26,7 @@ class EnableBankingCredentialsService {
     String redirectUri = kEbRedirectUri,
     String? defaultCountry,
   }) async {
+    validateEnableBankingRedirect(redirectUri);
     final application = await _api.verifyApplicationCredentials(
       appId: appId,
       privateKeyPem: privateKeyPem,
@@ -47,11 +48,10 @@ class EnableBankingCredentialsService {
         message: 'Sandbox credentials are not allowed in release builds',
       );
     }
-    if (!application.redirectUrls.contains(redirectUri)) {
-      throw const EnableBankingException(
-        message: 'Redirect URI is not registered for this application',
-      );
-    }
+    validateEnableBankingRedirect(
+      redirectUri,
+      registeredRedirects: application.redirectUrls,
+    );
 
     final normalizedDefaultCountry = defaultCountry?.toUpperCase();
     if (normalizedDefaultCountry != null &&

--- a/lib/services/banking/enable_banking/enable_banking_dependencies.dart
+++ b/lib/services/banking/enable_banking/enable_banking_dependencies.dart
@@ -1,71 +1,34 @@
+// dart format width=400
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
+import '../bank_authorization_context.dart';
+import '../banking_exception.dart';
 import 'enable_banking_api.dart';
 import 'enable_banking_auth.dart';
 import 'enable_banking_config.dart';
 import 'enable_banking_credentials_service.dart';
 import 'enable_banking_credentials_store.dart';
+import 'enable_banking_errors.dart';
 
 part 'enable_banking_dependencies.g.dart';
 
 @Riverpod(keepAlive: true)
-EnableBankingCredentialsStore enableBankingCredentialsStore(Ref ref) =>
-    const EnableBankingCredentialsStore();
+EnableBankingCredentialsStore enableBankingCredentialsStore(Ref ref) => const EnableBankingCredentialsStore();
 
 @Riverpod(keepAlive: true)
 EnableBankingAuth enableBankingAuth(Ref ref) => EnableBankingAuth();
 
 @Riverpod(keepAlive: true)
-EnableBankingApi enableBankingApi(Ref ref) => EnableBankingApi(
-  auth: ref.watch(enableBankingAuthProvider),
-  store: ref.watch(enableBankingCredentialsStoreProvider),
-);
+EnableBankingApi enableBankingApi(Ref ref) => EnableBankingApi(auth: ref.watch(enableBankingAuthProvider), store: ref.watch(enableBankingCredentialsStoreProvider));
 
 @Riverpod(keepAlive: true)
-EnableBankingCredentialsService enableBankingCredentialsService(Ref ref) =>
-    EnableBankingCredentialsService(
-      api: ref.watch(enableBankingApiProvider),
-      store: ref.watch(enableBankingCredentialsStoreProvider),
-    );
+EnableBankingCredentialsService enableBankingCredentialsService(Ref ref) => EnableBankingCredentialsService(api: ref.watch(enableBankingApiProvider), store: ref.watch(enableBankingCredentialsStoreProvider));
 
-@Riverpod(keepAlive: true)
-class EnableBankingSettings extends _$EnableBankingSettings {
-  @override
-  Future<EnableBankingConfig?> build() async {
-    final store = ref.watch(enableBankingCredentialsStoreProvider);
-    return store.readConfig();
-  }
-
-  Future<bool> hasCredentials() async {
-    final store = ref.watch(enableBankingCredentialsStoreProvider);
-    return store.hasCredentials();
-  }
-
-  Future<void> save({
-    required String appId,
-    required String privateKeyPem,
-    required EnableBankingConfig config,
-  }) async {
-    state = const AsyncLoading();
-    state = await AsyncValue.guard(() async {
-      final saved = await ref
-          .read(enableBankingCredentialsServiceProvider)
-          .saveVerifiedCredentials(
-            appId: appId,
-            privateKeyPem: privateKeyPem,
-            redirectUri: config.redirectUri,
-            defaultCountry: config.defaultCountry,
-          );
-      return saved;
-    });
-  }
-
-  Future<void> clear() async {
-    state = const AsyncLoading();
-    state = await AsyncValue.guard(() async {
-      final store = ref.read(enableBankingCredentialsStoreProvider);
-      await store.clear();
-      return null;
-    });
-  }
-}
+Future<BankAuthorizationContext> readEnableBankingAuthorizationContext(EnableBankingCredentialsStore store) => withEnableBankingErrors(() async {
+  final credentials = await store.readCredentials();
+  if (credentials == null) throw const BankingException(providerId: enableBankingId, failure: BankingFailure.authentication);
+  final config = credentials.config;
+  validateEnableBankingRedirect(config.redirectUri, registeredRedirects: config.redirectUrls);
+  return BankAuthorizationContext(providerId: enableBankingId, applicationId: config.appId, redirectUri: config.redirectUri);
+});

--- a/lib/services/banking/enable_banking/enable_banking_errors.dart
+++ b/lib/services/banking/enable_banking/enable_banking_errors.dart
@@ -16,12 +16,22 @@ Future<T> withEnableBankingErrors<T>(Future<T> Function() operation) async {
   try {
     return await operation();
   } on EnableBankingException catch (error) {
-    final failure = switch (error.statusCode) {
-      401 => BankingFailure.authentication,
-      403 => BankingFailure.forbidden,
-      429 => BankingFailure.rateLimited,
-      int code when code >= 500 => BankingFailure.unavailable,
-      _ => BankingFailure.rejected,
+    final failure = switch (error.kind) {
+      EnableBankingFailureKind.sessionExpired => BankingFailure.connectionExpired,
+      EnableBankingFailureKind.sessionRevoked => BankingFailure.connectionRevoked,
+      EnableBankingFailureKind.sessionClosed => BankingFailure.connectionClosed,
+      EnableBankingFailureKind.notFound => BankingFailure.notFound,
+      EnableBankingFailureKind.applicationAuthentication => error.statusCode == 403 ? BankingFailure.forbidden : BankingFailure.authentication,
+      EnableBankingFailureKind.rateLimited => BankingFailure.rateLimited,
+      EnableBankingFailureKind.timeout || EnableBankingFailureKind.server || EnableBankingFailureKind.network => BankingFailure.unavailable,
+      EnableBankingFailureKind.invalidResponse => BankingFailure.invalidResponse,
+      _ => switch (error.statusCode) {
+        401 => BankingFailure.authentication,
+        403 => BankingFailure.forbidden,
+        429 => BankingFailure.rateLimited,
+        int code when code >= 500 => BankingFailure.unavailable,
+        _ => BankingFailure.rejected,
+      },
     };
     throw BankingException(providerId: id, failure: failure);
   } on EnableBankingAuthException {

--- a/lib/services/banking/enable_banking/enable_banking_exception.dart
+++ b/lib/services/banking/enable_banking/enable_banking_exception.dart
@@ -1,20 +1,50 @@
-/// Error surfaced by the Enable Banking REST API (HTTP status >= 400).
-///
-/// [statusCode] lets callers detect an expired/revoked consent (401) to
-/// mark the connection as `EXPIRED` (see Step 14 of the implementation
-/// plan) instead of failing the whole sync.
+enum EnableBankingFailureKind {
+  applicationAuthentication,
+  sessionExpired,
+  sessionRevoked,
+  sessionClosed,
+  notFound,
+  rateLimited,
+  timeout,
+  server,
+  invalidRequest,
+  invalidResponse,
+  network,
+  unknown,
+}
+
 class EnableBankingException implements Exception {
   final int? statusCode;
   final String? error;
   final String? message;
+  final EnableBankingFailureKind kind;
 
-  const EnableBankingException({this.statusCode, this.error, this.message});
+  const EnableBankingException({
+    this.statusCode,
+    this.error,
+    this.message,
+    this.kind = EnableBankingFailureKind.unknown,
+  });
 
-  /// True when the consent/session is no longer valid.
+  bool get isRetryable => switch (kind) {
+    EnableBankingFailureKind.rateLimited ||
+    EnableBankingFailureKind.timeout ||
+    EnableBankingFailureKind.server ||
+    EnableBankingFailureKind.network => true,
+    _ => false,
+  };
+
   bool get isUnauthorized => statusCode == 401;
+
+  bool get confirmsMissingSession => switch (kind) {
+    EnableBankingFailureKind.sessionRevoked ||
+    EnableBankingFailureKind.sessionClosed ||
+    EnableBankingFailureKind.notFound => true,
+    _ => false,
+  };
 
   @override
   String toString() =>
       'EnableBankingException(statusCode: $statusCode, error: $error, '
-      'message: $message)';
+      'kind: $kind, message: $message)';
 }

--- a/lib/services/banking/enable_banking/models/eb_account.dart
+++ b/lib/services/banking/enable_banking/models/eb_account.dart
@@ -38,6 +38,15 @@ class EbAccount {
     usage: json['usage'] as String?,
     identificationHash: json['identification_hash'] as String?,
     identificationHashes: ((json['identification_hashes'] as List?) ?? const [])
-        .cast<String>(),
+        .map((value) => value as String)
+        .toList(growable: false),
   );
+
+  Set<String> get stableHashes => {
+    if (identificationHash case final String value when value.trim().isNotEmpty)
+      value.trim(),
+    ...identificationHashes
+        .map((value) => value.trim())
+        .where((value) => value.isNotEmpty),
+  };
 }

--- a/lib/services/banking/enable_banking/models/eb_session_details.dart
+++ b/lib/services/banking/enable_banking/models/eb_session_details.dart
@@ -1,3 +1,5 @@
+import '../enable_banking_exception.dart';
+
 enum EbSessionStatus {
   authorized,
   cancelled,
@@ -17,25 +19,28 @@ enum EbSessionStatus {
     'PENDING_AUTHORIZATION' => EbSessionStatus.pendingAuthorization,
     'RETURNED_FROM_BANK' => EbSessionStatus.returnedFromBank,
     'REVOKED' => EbSessionStatus.revoked,
-    _ => throw FormatException('Unknown session status: $value'),
+    _ => throw EnableBankingException(
+      message: 'Unknown session status: $value',
+      kind: EnableBankingFailureKind.invalidResponse,
+    ),
   };
 }
 
 class EbSessionAccount {
   final String uid;
-  final String identificationHash;
+  final String? identificationHash;
   final List<String> identificationHashes;
 
   const EbSessionAccount({
     required this.uid,
-    required this.identificationHash,
+    this.identificationHash,
     this.identificationHashes = const [],
   });
 
   static EbSessionAccount fromJson(Map<String, dynamic> json) =>
       EbSessionAccount(
         uid: json['uid'] as String,
-        identificationHash: json['identification_hash'] as String,
+        identificationHash: json['identification_hash'] as String?,
         identificationHashes:
             ((json['identification_hashes'] as List?) ?? const [])
                 .map((value) => value as String)

--- a/lib/services/banking/lifecycle/bank_authorization_callback.dart
+++ b/lib/services/banking/lifecycle/bank_authorization_callback.dart
@@ -1,0 +1,14 @@
+// dart format width=400
+
+class BankAuthorizationCallback {
+  final String? code;
+  final String? state;
+  final String? error;
+  final String? errorDescription;
+
+  const BankAuthorizationCallback({this.code, this.state, this.error, this.errorDescription});
+
+  bool get isSuccess => code != null && error == null;
+}
+
+enum BankCallbackDisposition { terminal, retryable }

--- a/lib/services/banking/lifecycle/bank_authorization_result.dart
+++ b/lib/services/banking/lifecycle/bank_authorization_result.dart
@@ -1,0 +1,34 @@
+// dart format width=400
+
+import '../../../model/bank_connection.dart';
+import '../banking_connection.dart';
+
+class AuthorizationAttempt {
+  final Uri url;
+  final DateTime consentValidUntil;
+
+  const AuthorizationAttempt({required this.url, required this.consentValidUntil});
+}
+
+class AuthorizationLaunchResult {
+  final Uri url;
+  final bool opened;
+
+  const AuthorizationLaunchResult({required this.url, required this.opened});
+}
+
+class StagedBankConnection {
+  final BankConnection connection;
+  final BankingConnectionResult? createdConnection;
+
+  const StagedBankConnection({required this.connection, this.createdConnection});
+}
+
+class ResumableBankConnection {
+  final BankConnection connection;
+  final BankingConnection details;
+
+  const ResumableBankConnection({required this.connection, required this.details});
+}
+
+typedef AuthorizationUrlLauncher = Future<bool> Function(Uri url);

--- a/lib/services/banking/lifecycle/bank_consent_lifecycle_service.dart
+++ b/lib/services/banking/lifecycle/bank_consent_lifecycle_service.dart
@@ -1,0 +1,343 @@
+// dart format width=400
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../model/bank_account.dart';
+import '../../../model/bank_account_link.dart';
+import '../../../model/bank_connection.dart';
+import '../../database/repositories/bank_connection_repository.dart';
+import '../bank_authorization_context.dart';
+import '../bank_consent_service.dart';
+import '../bank_institution.dart';
+import '../bank_institution_directory.dart';
+import '../banking_account.dart';
+import '../banking_authorization.dart';
+import '../banking_connection.dart';
+import '../banking_exception.dart';
+import '../banking_reference.dart';
+import 'bank_authorization_callback.dart';
+import 'bank_authorization_result.dart';
+import 'banking_platform_support.dart';
+import 'pending_bank_authorization.dart';
+import 'pending_bank_authorization_store.dart';
+
+const _kDefaultConsentValidity = Duration(days: 90);
+const _kAuthorizationLifetime = Duration(minutes: 15);
+
+class BankConsentLifecycleService {
+  final BankConsentService _consent;
+  final BankInstitutionDirectory _institutions;
+  final BankAuthorizationContextReader _readContext;
+  final PendingBankAuthorizationStore _pendingStore;
+  final BankConnectionRepository _connections;
+  final DateTime Function() _clock;
+  final bool Function() _callbackSupported;
+  final Random _random;
+
+  Future<void> _callbackQueue = Future.value();
+
+  BankConsentLifecycleService({required BankConsentService consent, required BankInstitutionDirectory institutions, required BankAuthorizationContextReader readContext, required PendingBankAuthorizationStore pendingStore, required BankConnectionRepository connections, DateTime Function()? clock, bool Function()? callbackSupported, Random? random})
+    : _consent = consent,
+      _institutions = institutions,
+      _readContext = readContext,
+      _pendingStore = pendingStore,
+      _connections = connections,
+      _clock = clock ?? DateTime.now,
+      _callbackSupported = callbackSupported ?? BankingPlatformSupport.supportsCallback,
+      _random = random ?? Random.secure();
+
+  Future<AuthorizationAttempt> startAuthorization(BankInstitution selectedBankInstitution, {int? reconnectConnectionId}) async {
+    if (!_callbackSupported()) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.rejected);
+    }
+    final config = await _readContext();
+    if (selectedBankInstitution.providerId != config.providerId) throw BankingException(providerId: config.providerId, failure: BankingFailure.rejected);
+    final existingPending = await _pendingStore.read();
+    if (existingPending != null) {
+      if (!existingPending.expiresAt.isAfter(_clock().toUtc())) {
+        await _pendingStore.clear();
+      } else if (existingPending.providerId == config.providerId && existingPending.applicationId == config.applicationId && existingPending.redirectUri == config.redirectUri && existingPending.institutionName == selectedBankInstitution.name && existingPending.institutionCountry == selectedBankInstitution.country && existingPending.reconnectConnectionId == reconnectConnectionId) {
+        return AuthorizationAttempt(url: Uri.parse(existingPending.authorizationUrl), consentValidUntil: existingPending.consentValidUntil);
+      } else {
+        throw const BankingException(providerId: 'application', failure: BankingFailure.rejected);
+      }
+    }
+
+    final institution = reconnectConnectionId == null ? selectedBankInstitution : await _freshReconnectBankInstitution(selectedBankInstitution, reconnectConnectionId, config.applicationId);
+    if (!institution.customerTypes.contains(BankingCustomerType.personal)) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.rejected);
+    }
+    final maximum = institution.maximumConsentDuration;
+    final validity = maximum == null ? _kDefaultConsentValidity : Duration(seconds: min(_kDefaultConsentValidity.inSeconds, max(0, maximum.inSeconds)));
+    if (validity == Duration.zero) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.invalidResponse);
+    }
+
+    final now = _clock().toUtc();
+    final state = _newState();
+    final consentValidUntil = now.add(validity);
+    final authorization = await _consent.startAuthorization(BankingAuthorizationRequest(institution: institution, state: state, validUntil: consentValidUntil, redirectUri: Uri.parse(config.redirectUri)));
+    final authorizationUri = authorization.uri;
+    if (authorization.providerId != config.providerId || authorization.authorizationId.trim().isEmpty || authorizationUri.host.isEmpty || authorizationUri.userInfo.isNotEmpty || !authorizationUri.hasScheme || authorizationUri.scheme != 'https') {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.invalidResponse);
+    }
+    await _pendingStore.save(
+      PendingBankAuthorization(
+        providerId: config.providerId,
+        state: state,
+        authorizationId: authorization.authorizationId,
+        authorizationUrl: authorization.uri.toString(),
+        applicationId: config.applicationId,
+        institutionName: institution.name,
+        institutionCountry: institution.country,
+        redirectUri: config.redirectUri,
+        expiresAt: now.add(_kAuthorizationLifetime),
+        consentValidUntil: consentValidUntil,
+        reconnectConnectionId: reconnectConnectionId,
+      ),
+    );
+    return AuthorizationAttempt(url: authorizationUri, consentValidUntil: consentValidUntil);
+  }
+
+  Future<AuthorizationLaunchResult> launchAuthorization(Uri url, {AuthorizationUrlLauncher? launcher}) async {
+    final opened = await (launcher ?? _launch)(url);
+    return AuthorizationLaunchResult(url: url, opened: opened);
+  }
+
+  Future<void> cancelAuthorization() => _pendingStore.clear();
+
+  Future<bool> clearExpiredAuthorization() async {
+    final pending = await _pendingStore.read();
+    if (pending == null || pending.expiresAt.isAfter(_clock().toUtc())) {
+      return false;
+    }
+    await _pendingStore.clear();
+    return true;
+  }
+
+  Future<StagedBankConnection> completeCallback(BankAuthorizationCallback callback) {
+    final completer = Completer<void>();
+    final previous = _callbackQueue;
+    _callbackQueue = previous.then((_) => completer.future);
+    return previous.then((_) async {
+      try {
+        return await _completeCallback(callback);
+      } finally {
+        completer.complete();
+      }
+    });
+  }
+
+  Future<BankCallbackDisposition> handleCallback(BankAuthorizationCallback callback, {Future<void> Function(StagedBankConnection result)? onStaged, Future<void> Function(Object error)? onError}) async {
+    try {
+      final staged = await completeCallback(callback);
+      if (onStaged != null) await onStaged(staged);
+      return BankCallbackDisposition.terminal;
+    } on BankingException catch (error) {
+      if (onError != null) await onError(error);
+      return error.isRetryable ? BankCallbackDisposition.retryable : BankCallbackDisposition.terminal;
+    } catch (error) {
+      if (onError != null) await onError(error);
+      return BankCallbackDisposition.retryable;
+    }
+  }
+
+  Future<StagedBankConnection> _completeCallback(BankAuthorizationCallback callback) async {
+    final pending = await _pendingStore.read();
+    if (pending == null) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.rejected);
+    }
+    if (callback.state == null || callback.state != pending.state) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.rejected);
+    }
+    if (!pending.expiresAt.isAfter(_clock().toUtc())) {
+      await _pendingStore.clear();
+      throw const BankingException(providerId: 'application', failure: BankingFailure.connectionExpired);
+    }
+    if (callback.error != null) {
+      await _pendingStore.clear();
+      throw const BankingException(providerId: 'application', failure: BankingFailure.rejected);
+    }
+    if (callback.code == null || callback.code!.trim().isEmpty) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.rejected);
+    }
+
+    final context = await _readContext();
+    if (context.providerId != pending.providerId || context.applicationId != pending.applicationId || context.redirectUri != pending.redirectUri) throw BankingException(providerId: pending.providerId, failure: BankingFailure.authentication);
+
+    if (pending.stagedConnectionId case final id?) {
+      return StagedBankConnection(connection: await _connections.selectById(id));
+    }
+    final durable = await _connections.findByPendingAuthorizationId(pending.authorizationId, providerId: pending.providerId);
+    if (durable != null) {
+      await _pendingStore.save(pending.copy(stagedConnectionId: durable.id, phase: PendingAuthorizationPhase.connectionStaged));
+      return StagedBankConnection(connection: durable);
+    }
+
+    final result = await _consent.createConnection(callback.code!);
+    if (result.connection.reference.providerId != pending.providerId ||
+        result.connection.institution.providerId != pending.providerId ||
+        result.connection.reference.remoteId.trim().isEmpty ||
+        result.connection.status != BankingConnectionStatus.active ||
+        !result.connection.validUntil.isAfter(_clock().toUtc()) ||
+        !result.connection.institution.customerTypes.contains(BankingCustomerType.personal) ||
+        result.connection.institution.name != pending.institutionName ||
+        result.connection.institution.country != pending.institutionCountry) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.invalidResponse);
+    }
+    final connection = await _connections.stageConnection(
+      providerId: pending.providerId,
+      authorizationId: pending.authorizationId,
+      applicationId: pending.applicationId,
+      institutionName: result.connection.institution.name,
+      institutionCountry: result.connection.institution.country,
+      remoteConnectionId: result.connection.reference.remoteId,
+      validUntil: result.connection.validUntil,
+      psuType: 'personal',
+      reconnectConnectionId: pending.reconnectConnectionId,
+    );
+    await _pendingStore.save(pending.copy(stagedConnectionId: connection.id, phase: PendingAuthorizationPhase.connectionStaged));
+    return StagedBankConnection(connection: connection, createdConnection: result);
+  }
+
+  Future<BankConnection> activateConnection(int connectionId, List<({BankingAccount remote, BankAccount? newAccount})> selections) async {
+    final staged = await _connections.selectById(connectionId);
+    if (selections.any((selection) => selection.remote.reference.providerId != staged.providerId)) throw BankingException(providerId: staged.providerId, failure: BankingFailure.rejected);
+    final links = selections.map((selection) => BankAccountLink(uid: selection.remote.reference.remoteId, identificationHashes: selection.remote.reference.identityKeys.map((value) => value.trim()).where((value) => value.isNotEmpty).toSet(), iban: selection.remote.iban, newAccount: selection.newAccount)).toList(growable: false);
+    final connection = await _connections.activateStagedConnection(connectionId, links);
+    final pending = await _pendingStore.read();
+    if (pending?.stagedConnectionId == connectionId) {
+      await _pendingStore.clear();
+    }
+    return connection;
+  }
+
+  Future<List<ResumableBankConnection>> resumeAwaitingImports() async {
+    final result = <ResumableBankConnection>[];
+    for (final connection in await _connections.selectAwaitingImport()) {
+      final remoteConnectionId = connection.pendingRemoteConnectionId;
+      if (remoteConnectionId == null) continue;
+      try {
+        final details = await _consent.getConnection(await _reference(connection, remoteConnectionId));
+        final localStatus = details.status == BankingConnectionStatus.active && details.isExpiredAt(_clock().toUtc()) ? BankConnectionStatus.expired : _localStatus(details.status);
+        if (localStatus != BankConnectionStatus.awaitingImport) {
+          await _rejectStagedConnection(connection, localStatus);
+          continue;
+        }
+        result.add(ResumableBankConnection(connection: connection, details: details));
+      } on BankingException catch (error) {
+        final status = _statusForFailure(error.failure);
+        if (status != null) {
+          await _rejectStagedConnection(connection, status);
+          continue;
+        }
+        rethrow;
+      }
+    }
+    return result;
+  }
+
+  Future<void> _rejectStagedConnection(BankConnection connection, BankConnectionStatus failedStatus) async {
+    final id = connection.id!;
+    if (failedStatus == BankConnectionStatus.reauthRequired) {
+      await _connections.markStatus(id, failedStatus);
+      return;
+    }
+    if (connection.remoteConnectionId == null) {
+      await _connections.failStagedConnection(id, failedStatus);
+    } else {
+      await _connections.discardStagedConnection(id);
+    }
+    final pending = await _pendingStore.read();
+    if (pending?.stagedConnectionId == id) await _pendingStore.clear();
+  }
+
+  Future<BankConnectionStatus> refreshConnectionState(BankConnection connection) async {
+    final id = connection.id;
+    final remoteConnectionId = connection.remoteConnectionId;
+    if (id == null || remoteConnectionId == null) {
+      return connection.status;
+    }
+    try {
+      final details = await _consent.getConnection(await _reference(connection, remoteConnectionId));
+      final status = switch (details.status) {
+        BankingConnectionStatus.active => details.validUntil.isAfter(_clock().toUtc()) ? BankConnectionStatus.active : BankConnectionStatus.expired,
+        BankingConnectionStatus.expired => BankConnectionStatus.expired,
+        BankingConnectionStatus.revoked || BankingConnectionStatus.closed => BankConnectionStatus.revoked,
+        BankingConnectionStatus.cancelled || BankingConnectionStatus.invalid => BankConnectionStatus.reauthRequired,
+        BankingConnectionStatus.pending => BankConnectionStatus.authorizing,
+      };
+      await _connections.markStatus(id, status);
+      return status;
+    } on BankingException catch (error) {
+      final status = _statusForFailure(error.failure);
+      if (status == null) rethrow;
+      await _connections.markStatus(id, status);
+      return status;
+    }
+  }
+
+  Future<void> revoke(BankConnection connection) async {
+    if (connection.id == null || connection.remoteConnectionId == null) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.rejected);
+    }
+    await _connections.markStatus(connection.id!, BankConnectionStatus.revocationPending);
+    try {
+      await _consent.revokeConnection(await _reference(connection, connection.remoteConnectionId!));
+    } on BankingException catch (error) {
+      if (!error.confirmsMissingConnection) rethrow;
+    }
+    await _connections.finalizeRemoteRevocation(connection.id!);
+  }
+
+  Future<void> disconnectLocally(BankConnection connection) async {
+    if (connection.id == null) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.rejected);
+    }
+    await _connections.disconnectLocally(connection.id!);
+  }
+
+  Future<BankInstitution> _freshReconnectBankInstitution(BankInstitution selected, int connectionId, String applicationId) async {
+    final connection = await _connections.selectById(connectionId);
+    if (connection.providerId != selected.providerId || connection.applicationId != applicationId || connection.institutionName != selected.name || connection.institutionCountry != selected.country) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.rejected);
+    }
+    final current = await _institutions.getInstitutions(country: selected.country);
+    return current.firstWhere(
+      (item) => item.providerId == selected.providerId && item.id == selected.id && item.name == selected.name && item.country == selected.country,
+      orElse: () => throw const BankingException(providerId: 'application', failure: BankingFailure.rejected),
+    );
+  }
+
+  BankConnectionStatus _localStatus(BankingConnectionStatus status) => switch (status) {
+    BankingConnectionStatus.active => BankConnectionStatus.awaitingImport,
+    BankingConnectionStatus.expired => BankConnectionStatus.expired,
+    BankingConnectionStatus.revoked || BankingConnectionStatus.closed => BankConnectionStatus.revoked,
+    BankingConnectionStatus.cancelled || BankingConnectionStatus.invalid => BankConnectionStatus.reauthRequired,
+    BankingConnectionStatus.pending => BankConnectionStatus.authorizing,
+  };
+
+  BankConnectionStatus? _statusForFailure(BankingFailure kind) => switch (kind) {
+    BankingFailure.connectionExpired => BankConnectionStatus.expired,
+    BankingFailure.connectionRevoked || BankingFailure.connectionClosed || BankingFailure.notFound => BankConnectionStatus.revoked,
+    BankingFailure.authentication || BankingFailure.forbidden => BankConnectionStatus.reauthRequired,
+    _ => null,
+  };
+
+  Future<BankingConnectionReference> _reference(BankConnection connection, String remoteId) async {
+    final context = await _readContext();
+    if (connection.providerId != context.providerId || connection.applicationId != context.applicationId) throw BankingException(providerId: connection.providerId, failure: BankingFailure.authentication);
+    return BankingConnectionReference(providerId: connection.providerId, remoteId: remoteId);
+  }
+
+  String _newState() {
+    final bytes = List<int>.generate(32, (_) => _random.nextInt(256));
+    return base64Url.encode(bytes).replaceAll('=', '');
+  }
+
+  static Future<bool> _launch(Uri url) => launchUrl(url, mode: LaunchMode.externalApplication);
+}

--- a/lib/services/banking/lifecycle/bank_deeplink_service.dart
+++ b/lib/services/banking/lifecycle/bank_deeplink_service.dart
@@ -1,0 +1,90 @@
+// dart format width=400
+
+import 'dart:async';
+
+import 'package:app_links/app_links.dart';
+
+import 'bank_authorization_callback.dart';
+
+abstract class UriLinkSource {
+  Stream<Uri> get uriStream;
+
+  Future<Uri?> getInitialUri();
+}
+
+class AppLinksUriSource implements UriLinkSource {
+  final AppLinks _appLinks;
+
+  AppLinksUriSource({AppLinks? appLinks}) : _appLinks = appLinks ?? AppLinks();
+
+  @override
+  Stream<Uri> get uriStream => _appLinks.uriLinkStream;
+
+  @override
+  Future<Uri?> getInitialUri() => _appLinks.getInitialLink();
+}
+
+class BankDeeplinkService {
+  final UriLinkSource _source;
+
+  StreamSubscription<Uri>? _subscription;
+  bool _initialLinkChecked = false;
+  final Set<String> _handled = {};
+  final Set<String> _inFlight = {};
+
+  BankDeeplinkService({UriLinkSource? source}) : _source = source ?? AppLinksUriSource();
+
+  static BankAuthorizationCallback? parse(Uri uri) {
+    // Preserve the callback route already registered by existing applications.
+    final redirect = Uri.parse('sossoldi://eb-callback');
+    if (uri.scheme != redirect.scheme || uri.host != redirect.host || uri.path != redirect.path || uri.port != redirect.port || uri.userInfo.isNotEmpty || uri.hasFragment) return null;
+    final params = uri.queryParametersAll;
+    final states = params['state'];
+    final codes = params['code'];
+    final errors = params['error'];
+    final descriptions = params['error_description'];
+    if (states?.length != 1 || states!.single.trim().isEmpty || (descriptions != null && descriptions.length != 1)) return null;
+    if (errors != null) {
+      if (errors.length != 1 || errors.single.trim().isEmpty || codes != null) return null;
+    } else if (codes?.length != 1 || codes!.single.trim().isEmpty) {
+      return null;
+    }
+    return BankAuthorizationCallback(code: codes?.single, state: states.single, error: errors?.single, errorDescription: descriptions?.single);
+  }
+
+  Future<void> start(Future<BankCallbackDisposition> Function(BankAuthorizationCallback) onCallback, {Future<void> Function(Object error)? onError}) async {
+    _subscription ??= _source.uriStream.listen((uri) => unawaited(_dispatch(uri, onCallback, onError)), onError: (Object error) => unawaited(_notifyError(error, onError)));
+    if (_initialLinkChecked) return;
+    _initialLinkChecked = true;
+    try {
+      final initial = await _source.getInitialUri();
+      if (initial != null) await _dispatch(initial, onCallback, onError);
+    } catch (error) {
+      await _notifyError(error, onError);
+    }
+  }
+
+  Future<void> _dispatch(Uri uri, Future<BankCallbackDisposition> Function(BankAuthorizationCallback) onCallback, Future<void> Function(Object error)? onError) async {
+    final key = uri.toString();
+    if (_handled.contains(key) || !_inFlight.add(key)) return;
+    try {
+      final callback = parse(uri);
+      if (callback == null) return;
+      final disposition = await onCallback(callback);
+      if (disposition == BankCallbackDisposition.terminal) _handled.add(key);
+    } catch (error) {
+      await _notifyError(error, onError);
+    } finally {
+      _inFlight.remove(key);
+    }
+  }
+
+  Future<void> _notifyError(Object error, Future<void> Function(Object error)? onError) async {
+    if (onError != null) await onError(error);
+  }
+
+  Future<void> dispose() async {
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+}

--- a/lib/services/banking/lifecycle/banking_backup_policy.dart
+++ b/lib/services/banking/lifecycle/banking_backup_policy.dart
@@ -1,0 +1,25 @@
+// dart format width=400
+
+import '../../../model/bank_account.dart';
+import '../../../model/bank_connection.dart';
+
+class BankingBackupPolicy {
+  const BankingBackupPolicy._();
+
+  static Map<String, Object?> sanitizeForExport(String table, Map<String, Object?> row) {
+    final sanitized = Map<String, Object?>.from(row);
+    if (table == bankConnectionTable) {
+      sanitized[BankConnectionFields.remoteConnectionId] = null;
+      sanitized[BankConnectionFields.pendingRemoteConnectionId] = null;
+      sanitized[BankConnectionFields.pendingAuthorizationId] = null;
+      sanitized[BankConnectionFields.pendingValidUntil] = null;
+      sanitized[BankConnectionFields.status] = BankConnectionStatus.reauthRequired.code;
+    } else if (table == bankAccountTable) {
+      sanitized[BankAccountFields.ebAccountUid] = null;
+      sanitized[BankAccountFields.lastSyncAt] = null;
+    }
+    return sanitized;
+  }
+
+  static Map<String, Object?> sanitizeForRestore(String table, Map<String, Object?> row) => sanitizeForExport(table, row);
+}

--- a/lib/services/banking/lifecycle/banking_platform_support.dart
+++ b/lib/services/banking/lifecycle/banking_platform_support.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/foundation.dart';
+
+class BankingPlatformSupport {
+  const BankingPlatformSupport._();
+
+  static bool supportsCallback({
+    TargetPlatform? platform,
+    bool isWeb = kIsWeb,
+  }) {
+    if (isWeb) return false;
+    return switch (platform ?? defaultTargetPlatform) {
+      TargetPlatform.android ||
+      TargetPlatform.iOS ||
+      TargetPlatform.macOS => true,
+      TargetPlatform.windows ||
+      TargetPlatform.linux ||
+      TargetPlatform.fuchsia => false,
+    };
+  }
+}

--- a/lib/services/banking/lifecycle/pending_bank_authorization.dart
+++ b/lib/services/banking/lifecycle/pending_bank_authorization.dart
@@ -1,0 +1,108 @@
+// dart format width=400
+
+import '../banking_exception.dart';
+
+enum PendingAuthorizationPhase {
+  awaitingCallback,
+  connectionStaged;
+
+  // Keep the serialized phase compatible with pending authorizations saved before the naming cleanup.
+  String get code => switch (this) {
+    PendingAuthorizationPhase.awaitingCallback => 'awaitingCallback',
+    PendingAuthorizationPhase.connectionStaged => 'sessionStaged',
+  };
+
+  static PendingAuthorizationPhase fromCode(String code) => PendingAuthorizationPhase.values.firstWhere((phase) => phase.code == code);
+}
+
+class PendingBankAuthorization {
+  static const _unset = Object();
+
+  final String providerId;
+  final String state;
+  final String authorizationId;
+  final String authorizationUrl;
+  final String applicationId;
+  final String institutionName;
+  final String institutionCountry;
+  final String redirectUri;
+  final DateTime expiresAt;
+  final DateTime consentValidUntil;
+  final int? reconnectConnectionId;
+  final int? stagedConnectionId;
+  final PendingAuthorizationPhase phase;
+
+  const PendingBankAuthorization({
+    required this.providerId,
+    required this.state,
+    required this.authorizationId,
+    required this.authorizationUrl,
+    required this.applicationId,
+    required this.institutionName,
+    required this.institutionCountry,
+    required this.redirectUri,
+    required this.expiresAt,
+    required this.consentValidUntil,
+    this.reconnectConnectionId,
+    this.stagedConnectionId,
+    this.phase = PendingAuthorizationPhase.awaitingCallback,
+  });
+
+  PendingBankAuthorization copy({Object? stagedConnectionId = _unset, PendingAuthorizationPhase? phase}) => PendingBankAuthorization(
+    providerId: providerId,
+    state: state,
+    authorizationId: authorizationId,
+    authorizationUrl: authorizationUrl,
+    applicationId: applicationId,
+    institutionName: institutionName,
+    institutionCountry: institutionCountry,
+    redirectUri: redirectUri,
+    expiresAt: expiresAt,
+    consentValidUntil: consentValidUntil,
+    reconnectConnectionId: reconnectConnectionId,
+    stagedConnectionId: stagedConnectionId == _unset ? this.stagedConnectionId : stagedConnectionId as int?,
+    phase: phase ?? this.phase,
+  );
+
+  Map<String, Object?> toJson() => {
+    'version': 1,
+    'provider_id': providerId,
+    'state': state,
+    'authorization_id': authorizationId,
+    'authorization_url': authorizationUrl,
+    'application_id': applicationId,
+    'aspsp_name': institutionName,
+    'aspsp_country': institutionCountry,
+    'redirect_uri': redirectUri,
+    'expires_at': expiresAt.toUtc().toIso8601String(),
+    'consent_valid_until': consentValidUntil.toUtc().toIso8601String(),
+    'reconnect_connection_id': reconnectConnectionId,
+    'staged_connection_id': stagedConnectionId,
+    'phase': phase.code,
+  };
+
+  static PendingBankAuthorization fromJson(Map<String, dynamic> json) {
+    try {
+      if (json['version'] != 1) {
+        throw const FormatException('unsupported pending authorization');
+      }
+      return PendingBankAuthorization(
+        providerId: json['provider_id'] as String? ?? 'enable_banking',
+        state: json['state'] as String,
+        authorizationId: json['authorization_id'] as String,
+        authorizationUrl: json['authorization_url'] as String,
+        applicationId: json['application_id'] as String,
+        institutionName: json['aspsp_name'] as String,
+        institutionCountry: json['aspsp_country'] as String,
+        redirectUri: json['redirect_uri'] as String,
+        expiresAt: DateTime.parse(json['expires_at'] as String).toUtc(),
+        consentValidUntil: DateTime.parse(json['consent_valid_until'] as String).toUtc(),
+        reconnectConnectionId: json['reconnect_connection_id'] as int?,
+        stagedConnectionId: json['staged_connection_id'] as int?,
+        phase: PendingAuthorizationPhase.fromCode(json['phase'] as String),
+      );
+    } catch (error) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.invalidResponse);
+    }
+  }
+}

--- a/lib/services/banking/lifecycle/pending_bank_authorization_store.dart
+++ b/lib/services/banking/lifecycle/pending_bank_authorization_store.dart
@@ -1,0 +1,44 @@
+// dart format width=400
+
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../banking_exception.dart';
+import 'pending_bank_authorization.dart';
+
+// Preserve the storage key used by existing pending authorizations.
+const _kPendingAuthorizationKey = 'eb_pending_authorization_v1';
+
+abstract class PendingBankAuthorizationStore {
+  Future<void> save(PendingBankAuthorization pending);
+
+  Future<PendingBankAuthorization?> read();
+
+  Future<void> clear();
+}
+
+class SecurePendingBankAuthorizationStore implements PendingBankAuthorizationStore {
+  final FlutterSecureStorage _storage;
+
+  const SecurePendingBankAuthorizationStore({FlutterSecureStorage? storage}) : _storage = storage ?? const FlutterSecureStorage();
+
+  @override
+  Future<void> save(PendingBankAuthorization pending) => _storage.write(key: _kPendingAuthorizationKey, value: jsonEncode(pending.toJson()));
+
+  @override
+  Future<PendingBankAuthorization?> read() async {
+    final value = await _storage.read(key: _kPendingAuthorizationKey);
+    if (value == null) return null;
+    try {
+      return PendingBankAuthorization.fromJson(jsonDecode(value) as Map<String, dynamic>);
+    } on BankingException {
+      rethrow;
+    } catch (error) {
+      throw const BankingException(providerId: 'application', failure: BankingFailure.invalidResponse);
+    }
+  }
+
+  @override
+  Future<void> clear() => _storage.delete(key: _kPendingAuthorizationKey);
+}

--- a/lib/services/database/migrations/0008_add_bank_consent_lifecycle.dart
+++ b/lib/services/database/migrations/0008_add_bank_consent_lifecycle.dart
@@ -1,0 +1,96 @@
+// dart format width=400
+
+// ignore_for_file: file_names
+
+import 'package:sqflite/sqflite.dart';
+
+import '../../../model/bank_account.dart';
+import '../../../model/bank_connection.dart';
+import '../migration_base.dart';
+
+class AddBankConsentLifecycle extends Migration {
+  AddBankConsentLifecycle() : super(version: 8, description: 'Add bank consent lifecycle and stable account identity');
+
+  @override
+  Future<void> up(Database db) async {
+    await db.execute('''
+      CREATE TABLE `$bankConnectionTable` (
+        `${BankConnectionFields.id}` INTEGER PRIMARY KEY AUTOINCREMENT,
+        `${BankConnectionFields.institutionName}` TEXT NOT NULL,
+        `${BankConnectionFields.institutionCountry}` TEXT NOT NULL,
+        `${BankConnectionFields.applicationId}` TEXT NOT NULL,
+        `${BankConnectionFields.remoteConnectionId}` TEXT,
+        `${BankConnectionFields.pendingRemoteConnectionId}` TEXT,
+        `${BankConnectionFields.pendingAuthorizationId}` TEXT,
+        `${BankConnectionFields.validUntil}` TEXT,
+        `${BankConnectionFields.pendingValidUntil}` TEXT,
+        `${BankConnectionFields.status}` TEXT NOT NULL CHECK (
+          `${BankConnectionFields.status}` IN (
+            'AUTHORIZING', 'AWAITING_IMPORT', 'ACTIVE', 'EXPIRED',
+            'REVOKED', 'REAUTH_REQUIRED', 'REVOCATION_PENDING', 'DISCONNECTED'
+          )
+        ),
+        `${BankConnectionFields.psuType}` TEXT NOT NULL DEFAULT 'personal'
+          CHECK (`${BankConnectionFields.psuType}` = 'personal'),
+        `${BankConnectionFields.createdAt}` TEXT NOT NULL,
+        `${BankConnectionFields.updatedAt}` TEXT NOT NULL
+      )
+    ''');
+    await db.execute('''
+      CREATE UNIQUE INDEX `idx_bank_connection_session`
+      ON `$bankConnectionTable` (`${BankConnectionFields.remoteConnectionId}`)
+      WHERE `${BankConnectionFields.remoteConnectionId}` IS NOT NULL
+    ''');
+    await db.execute('''
+      CREATE UNIQUE INDEX `idx_bank_connection_pending_authorization`
+      ON `$bankConnectionTable`
+      (`${BankConnectionFields.pendingAuthorizationId}`)
+      WHERE `${BankConnectionFields.pendingAuthorizationId}` IS NOT NULL
+    ''');
+
+    await db.execute(
+      'ALTER TABLE `$bankAccountTable` ADD COLUMN '
+      '`${BankAccountFields.ebAccountUid}` TEXT',
+    );
+    await db.execute(
+      'ALTER TABLE `$bankAccountTable` ADD COLUMN '
+      '`${BankAccountFields.ebConnectionId}` INTEGER',
+    );
+    await db.execute(
+      'ALTER TABLE `$bankAccountTable` ADD COLUMN '
+      '`${BankAccountFields.identificationHash}` TEXT',
+    );
+    await db.execute(
+      'ALTER TABLE `$bankAccountTable` ADD COLUMN '
+      '`${BankAccountFields.identificationHashes}` TEXT',
+    );
+    await db.execute(
+      'ALTER TABLE `$bankAccountTable` ADD COLUMN '
+      '`${BankAccountFields.iban}` TEXT',
+    );
+    await db.execute(
+      'ALTER TABLE `$bankAccountTable` ADD COLUMN '
+      '`${BankAccountFields.lastSyncAt}` TEXT',
+    );
+
+    await db.execute('''
+      CREATE TABLE `$bankAccountIdentityTable` (
+        `${BankAccountIdentityFields.connectionId}` INTEGER NOT NULL,
+        `${BankAccountIdentityFields.bankAccountId}` INTEGER NOT NULL,
+        `${BankAccountIdentityFields.identificationHash}` TEXT NOT NULL,
+        PRIMARY KEY (
+          `${BankAccountIdentityFields.connectionId}`,
+          `${BankAccountIdentityFields.identificationHash}`
+        ),
+        UNIQUE (
+          `${BankAccountIdentityFields.bankAccountId}`,
+          `${BankAccountIdentityFields.identificationHash}`
+        )
+      )
+    ''');
+    await db.execute('''
+      CREATE INDEX `idx_bank_account_connection`
+      ON `$bankAccountTable` (`${BankAccountFields.ebConnectionId}`)
+    ''');
+  }
+}

--- a/lib/services/database/migrations/0009_add_bank_provider_identity.dart
+++ b/lib/services/database/migrations/0009_add_bank_provider_identity.dart
@@ -1,0 +1,22 @@
+// dart format width=400
+
+// ignore_for_file: file_names
+// dart format width=400
+
+import 'package:sqflite/sqflite.dart';
+
+import '../../../model/bank_connection.dart';
+import '../migration_base.dart';
+
+class AddBankProviderIdentity extends Migration {
+  AddBankProviderIdentity() : super(version: 9, description: 'Namespace persisted connections by banking provider');
+
+  @override
+  Future<void> up(Database db) async {
+    await db.execute("ALTER TABLE `$bankConnectionTable` ADD COLUMN `${BankConnectionFields.providerId}` TEXT NOT NULL DEFAULT 'enable_banking'");
+    await db.execute('DROP INDEX idx_bank_connection_session');
+    await db.execute('DROP INDEX idx_bank_connection_pending_authorization');
+    await db.execute('CREATE UNIQUE INDEX idx_bank_connection_session ON `$bankConnectionTable` (`${BankConnectionFields.providerId}`, `${BankConnectionFields.remoteConnectionId}`) WHERE `${BankConnectionFields.remoteConnectionId}` IS NOT NULL');
+    await db.execute('CREATE UNIQUE INDEX idx_bank_connection_pending_authorization ON `$bankConnectionTable` (`${BankConnectionFields.providerId}`, `${BankConnectionFields.pendingAuthorizationId}`) WHERE `${BankConnectionFields.pendingAuthorizationId}` IS NOT NULL');
+  }
+}

--- a/lib/services/database/migrations/migration_registry.dart
+++ b/lib/services/database/migrations/migration_registry.dart
@@ -18,6 +18,8 @@ import '0004_add_category_order.dart';
 import '0005_add_account_order.dart';
 import '0006_migrate_icons_name.dart';
 import '0007_add_deleted_at.dart';
+import '0008_add_bank_consent_lifecycle.dart';
+import '0009_add_bank_provider_identity.dart';
 
 import '../migration_base.dart';
 
@@ -36,6 +38,8 @@ List<Migration> getMigrations() {
     AddAccountOrder(),
     MigrateIconsName(),
     AddDeletedAt(),
+    AddBankConsentLifecycle(),
+    AddBankProviderIdentity(),
   ];
 }
 

--- a/lib/services/database/repositories/bank_connection_repository.dart
+++ b/lib/services/database/repositories/bank_connection_repository.dart
@@ -1,0 +1,300 @@
+// dart format width=400
+
+import 'dart:convert';
+
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:sqflite/sqflite.dart';
+
+import '../../../model/bank_account.dart';
+import '../../../model/bank_account_link.dart';
+import '../../../model/bank_connection.dart';
+import '../sossoldi_database.dart';
+import 'bank_reconciliation_exception.dart';
+
+part 'bank_connection_repository.g.dart';
+
+@Riverpod(keepAlive: true)
+BankConnectionRepository bankConnectionRepository(Ref ref) => BankConnectionRepository(database: ref.watch(databaseProvider));
+
+class BankConnectionRepository {
+  BankConnectionRepository({required SossoldiDatabase database}) : _database = database.database;
+
+  BankConnectionRepository.withDatabase(Database database) : _database = Future.value(database);
+
+  final Future<Database> _database;
+
+  Future<BankConnection> insert(BankConnection item) async {
+    final db = await _database;
+    final values = item.toJson()..remove(BankConnectionFields.id);
+    final id = await db.insert(bankConnectionTable, values);
+    return selectById(id);
+  }
+
+  Future<BankConnection?> findById(int id) async {
+    final db = await _database;
+    final rows = await db.query(bankConnectionTable, columns: BankConnectionFields.allFields, where: '${BankConnectionFields.id} = ?', whereArgs: [id], limit: 1);
+    return rows.isEmpty ? null : BankConnection.fromJson(rows.single);
+  }
+
+  Future<BankConnection> selectById(int id) async {
+    final item = await findById(id);
+    if (item == null) throw StateError('Bank connection $id not found');
+    return item;
+  }
+
+  Future<BankConnection?> findByPendingAuthorizationId(String id, {required String providerId}) async {
+    final db = await _database;
+    final rows = await db.query(bankConnectionTable, columns: BankConnectionFields.allFields, where: '${BankConnectionFields.pendingAuthorizationId} = ? AND ${BankConnectionFields.providerId} = ?', whereArgs: [id, providerId], limit: 1);
+    return rows.isEmpty ? null : BankConnection.fromJson(rows.single);
+  }
+
+  Future<List<BankConnection>> selectAll() async {
+    final db = await _database;
+    final rows = await db.query(bankConnectionTable, columns: BankConnectionFields.allFields, orderBy: '${BankConnectionFields.createdAt} ASC');
+    return rows.map(BankConnection.fromJson).toList(growable: false);
+  }
+
+  Future<List<BankConnection>> selectAwaitingImport() async {
+    final db = await _database;
+    final rows = await db.query(bankConnectionTable, columns: BankConnectionFields.allFields, where: '${BankConnectionFields.pendingRemoteConnectionId} IS NOT NULL');
+    return rows.map(BankConnection.fromJson).toList(growable: false);
+  }
+
+  Future<List<BankConnection>> selectActive({required String applicationId, DateTime? clock}) async {
+    final db = await _database;
+    final now = (clock ?? DateTime.now()).toUtc().toIso8601String();
+    return db.transaction((txn) async {
+      await txn.update(
+        bankConnectionTable,
+        {BankConnectionFields.status: BankConnectionStatus.expired.code, BankConnectionFields.updatedAt: now},
+        where:
+            '${BankConnectionFields.status} = ? AND '
+            '${BankConnectionFields.validUntil} <= ?',
+        whereArgs: [BankConnectionStatus.active.code, now],
+      );
+      final rows = await txn.query(
+        bankConnectionTable,
+        columns: BankConnectionFields.allFields,
+        where:
+            '${BankConnectionFields.applicationId} = ? AND '
+            '${BankConnectionFields.status} = ? AND '
+            '${BankConnectionFields.validUntil} > ?',
+        whereArgs: [applicationId, BankConnectionStatus.active.code, now],
+      );
+      return rows.map(BankConnection.fromJson).toList(growable: false);
+    });
+  }
+
+  Future<BankConnection> stageConnection({required String providerId, required String authorizationId, required String applicationId, required String institutionName, required String institutionCountry, required String remoteConnectionId, required DateTime validUntil, required String psuType, int? reconnectConnectionId}) async {
+    if (psuType != 'personal') {
+      throw const BankReconciliationException(BankReconciliationFailure.invalidConnectionState, 'Only personal bank connections are supported');
+    }
+    final db = await _database;
+    return db.transaction((txn) async {
+      final duplicate = await txn.query(bankConnectionTable, columns: BankConnectionFields.allFields, where: '${BankConnectionFields.pendingAuthorizationId} = ? AND ${BankConnectionFields.providerId} = ?', whereArgs: [authorizationId, providerId], limit: 1);
+      if (duplicate.isNotEmpty) {
+        return BankConnection.fromJson(duplicate.single);
+      }
+
+      final now = DateTime.now().toUtc();
+      if (reconnectConnectionId == null) {
+        final connection = BankConnection(providerId: providerId, institutionName: institutionName, institutionCountry: institutionCountry, applicationId: applicationId, pendingRemoteConnectionId: remoteConnectionId, pendingAuthorizationId: authorizationId, pendingValidUntil: validUntil, status: BankConnectionStatus.awaitingImport, psuType: psuType);
+        final values = connection.toJson(clock: now)..remove(BankConnectionFields.id);
+        final id = await txn.insert(bankConnectionTable, values);
+        return connection.copy(id: id, createdAt: now, updatedAt: now);
+      }
+
+      final rows = await txn.query(bankConnectionTable, columns: BankConnectionFields.allFields, where: '${BankConnectionFields.id} = ?', whereArgs: [reconnectConnectionId], limit: 1);
+      if (rows.isEmpty) {
+        throw const BankReconciliationException(BankReconciliationFailure.invalidConnectionState, 'Reconnect target does not exist');
+      }
+      final existing = BankConnection.fromJson(rows.single);
+      if (existing.providerId != providerId || existing.applicationId != applicationId || existing.institutionName != institutionName || existing.institutionCountry != institutionCountry || !{BankConnectionStatus.active, BankConnectionStatus.expired, BankConnectionStatus.reauthRequired}.contains(existing.status)) {
+        throw const BankReconciliationException(BankReconciliationFailure.invalidConnectionState, 'Reconnect authorization does not match the existing connection');
+      }
+      final staged = existing.copy(pendingRemoteConnectionId: remoteConnectionId, pendingAuthorizationId: authorizationId, pendingValidUntil: validUntil, psuType: psuType);
+      await txn.update(
+        bankConnectionTable,
+        staged.toJson(update: true, clock: now),
+        where: '${BankConnectionFields.id} = ?',
+        whereArgs: [existing.id],
+      );
+      return staged.copy(updatedAt: now);
+    });
+  }
+
+  Future<BankConnection> activateStagedConnection(int connectionId, List<BankAccountLink> links) async {
+    final db = await _database;
+    return db.transaction((txn) async {
+      final connectionRows = await txn.query(bankConnectionTable, columns: BankConnectionFields.allFields, where: '${BankConnectionFields.id} = ?', whereArgs: [connectionId], limit: 1);
+      if (connectionRows.isEmpty) {
+        throw const BankReconciliationException(BankReconciliationFailure.invalidConnectionState, 'Connection does not exist');
+      }
+      final connection = BankConnection.fromJson(connectionRows.single);
+      if (connection.pendingRemoteConnectionId == null || connection.pendingValidUntil == null) {
+        throw const BankReconciliationException(BankReconciliationFailure.invalidConnectionState, 'Connection has no staged remote connection');
+      }
+      if (links.isEmpty) {
+        throw const BankReconciliationException(BankReconciliationFailure.missingLocalAccount, 'At least one account must be selected before activation');
+      }
+
+      final normalized = <BankAccountLink>[];
+      final remoteHashes = <String>{};
+      for (final link in links) {
+        final hashes = link.identificationHashes.map((hash) => hash.trim()).where((hash) => hash.isNotEmpty).toSet();
+        if (link.uid.trim().isEmpty || hashes.isEmpty) {
+          throw const BankReconciliationException(BankReconciliationFailure.missingStableIdentity, 'A selected account has no stable identification hash');
+        }
+        if (hashes.any(remoteHashes.contains)) {
+          throw const BankReconciliationException(BankReconciliationFailure.identityCollision, 'Two remote accounts expose the same identification hash');
+        }
+        remoteHashes.addAll(hashes);
+        normalized.add(BankAccountLink(uid: link.uid.trim(), identificationHashes: hashes, iban: link.iban, newAccount: link.newAccount));
+      }
+
+      final identityRows = await txn.query(bankAccountIdentityTable, where: '${BankAccountIdentityFields.connectionId} = ?', whereArgs: [connectionId]);
+      final identityOwners = <String, int>{for (final row in identityRows) row[BankAccountIdentityFields.identificationHash] as String: row[BankAccountIdentityFields.bankAccountId] as int};
+      final selectedAccountIds = <int>{};
+
+      for (final link in normalized) {
+        final matchingIds = link.identificationHashes.map((hash) => identityOwners[hash]).whereType<int>().toSet();
+        if (matchingIds.length > 1) {
+          throw const BankReconciliationException(BankReconciliationFailure.identityCollision, 'Stable hashes resolve to different local accounts');
+        }
+
+        int accountId;
+        if (matchingIds.length == 1) {
+          accountId = matchingIds.single;
+        } else if (link.newAccount?.id case final int existingId) {
+          final selectedRows = await txn.query(bankAccountTable, columns: [BankAccountFields.ebConnectionId], where: '${BankAccountFields.id} = ?', whereArgs: [existingId], limit: 1);
+          if (selectedRows.isEmpty || (selectedRows.single[BankAccountFields.ebConnectionId] != null && selectedRows.single[BankAccountFields.ebConnectionId] != connectionId)) {
+            throw const BankReconciliationException(BankReconciliationFailure.missingLocalAccount, 'Selected local account belongs to another connection');
+          }
+          accountId = existingId;
+        } else if (link.newAccount case final draft?) {
+          final count = Sqflite.firstIntValue(await txn.rawQuery('SELECT COUNT(*) FROM `$bankAccountTable`')) ?? 0;
+          final values = draft.copy(order: count).toJson()..remove(BankAccountFields.id);
+          accountId = await txn.insert(bankAccountTable, values);
+        } else {
+          throw const BankReconciliationException(BankReconciliationFailure.missingLocalAccount, 'A new remote account needs a local account definition');
+        }
+        if (!selectedAccountIds.add(accountId)) {
+          throw const BankReconciliationException(BankReconciliationFailure.identityCollision, 'One local account was selected more than once');
+        }
+
+        final sortedHashes = link.identificationHashes.toList()..sort();
+        final changed = await txn.update(
+          bankAccountTable,
+          {BankAccountFields.ebAccountUid: link.uid, BankAccountFields.ebConnectionId: connectionId, BankAccountFields.identificationHash: sortedHashes.first, BankAccountFields.identificationHashes: jsonEncode(sortedHashes), BankAccountFields.iban: link.iban, BankAccountFields.active: 1, BankAccountFields.updatedAt: DateTime.now().toUtc().toIso8601String()},
+          where: '${BankAccountFields.id} = ?',
+          whereArgs: [accountId],
+        );
+        if (changed != 1) {
+          throw const BankReconciliationException(BankReconciliationFailure.missingLocalAccount, 'Selected local account does not exist');
+        }
+        await txn.delete(
+          bankAccountIdentityTable,
+          where:
+              '${BankAccountIdentityFields.connectionId} = ? AND '
+              '${BankAccountIdentityFields.bankAccountId} = ?',
+          whereArgs: [connectionId, accountId],
+        );
+        for (final hash in sortedHashes) {
+          await txn.insert(bankAccountIdentityTable, {BankAccountIdentityFields.connectionId: connectionId, BankAccountIdentityFields.bankAccountId: accountId, BankAccountIdentityFields.identificationHash: hash});
+        }
+      }
+
+      final linkedRows = await txn.query(bankAccountTable, columns: [BankAccountFields.id], where: '${BankAccountFields.ebConnectionId} = ?', whereArgs: [connectionId]);
+      for (final row in linkedRows) {
+        final accountId = row[BankAccountFields.id] as int;
+        if (selectedAccountIds.contains(accountId)) continue;
+        await _unlinkAccount(txn, connectionId, accountId);
+      }
+
+      final activated = connection.copy(remoteConnectionId: connection.pendingRemoteConnectionId, pendingRemoteConnectionId: null, pendingAuthorizationId: null, validUntil: connection.pendingValidUntil, pendingValidUntil: null, status: BankConnectionStatus.active);
+      await txn.update(bankConnectionTable, activated.toJson(update: true), where: '${BankConnectionFields.id} = ?', whereArgs: [connectionId]);
+      return activated;
+    });
+  }
+
+  Future<void> markStatus(int id, BankConnectionStatus status) async {
+    final db = await _database;
+    final changed = await db.update(bankConnectionTable, {BankConnectionFields.status: status.code, BankConnectionFields.updatedAt: DateTime.now().toUtc().toIso8601String()}, where: '${BankConnectionFields.id} = ?', whereArgs: [id]);
+    if (changed != 1) throw StateError('Bank connection $id not found');
+  }
+
+  Future<void> discardStagedConnection(int id) async {
+    final db = await _database;
+    final changed = await db.update(
+      bankConnectionTable,
+      {BankConnectionFields.pendingRemoteConnectionId: null, BankConnectionFields.pendingAuthorizationId: null, BankConnectionFields.pendingValidUntil: null, BankConnectionFields.updatedAt: DateTime.now().toUtc().toIso8601String()},
+      where:
+          '${BankConnectionFields.id} = ? AND '
+          '${BankConnectionFields.remoteConnectionId} IS NOT NULL',
+      whereArgs: [id],
+    );
+    if (changed != 1) {
+      throw StateError('Bank connection $id has no previous remote connection');
+    }
+  }
+
+  Future<void> failStagedConnection(int id, BankConnectionStatus status) async {
+    final db = await _database;
+    final changed = await db.update(bankConnectionTable, {BankConnectionFields.pendingRemoteConnectionId: null, BankConnectionFields.pendingAuthorizationId: null, BankConnectionFields.pendingValidUntil: null, BankConnectionFields.status: status.code, BankConnectionFields.updatedAt: DateTime.now().toUtc().toIso8601String()}, where: '${BankConnectionFields.id} = ?', whereArgs: [id]);
+    if (changed != 1) throw StateError('Bank connection $id not found');
+  }
+
+  Future<void> markOtherApplicationsReauthRequired(String applicationId, {required String providerId}) async {
+    final db = await _database;
+    await db.update(
+      bankConnectionTable,
+      {BankConnectionFields.status: BankConnectionStatus.reauthRequired.code, BankConnectionFields.updatedAt: DateTime.now().toUtc().toIso8601String()},
+      where:
+          '${BankConnectionFields.providerId} = ? AND ${BankConnectionFields.applicationId} != ? AND '
+          '${BankConnectionFields.status} NOT IN (?, ?, ?)',
+      whereArgs: [providerId, applicationId, BankConnectionStatus.revoked.code, BankConnectionStatus.disconnected.code, BankConnectionStatus.revocationPending.code],
+    );
+  }
+
+  Future<void> markAllReauthRequired({required String providerId}) async {
+    final db = await _database;
+    await db.update(
+      bankConnectionTable,
+      {BankConnectionFields.status: BankConnectionStatus.reauthRequired.code, BankConnectionFields.updatedAt: DateTime.now().toUtc().toIso8601String()},
+      where: '${BankConnectionFields.providerId} = ? AND ${BankConnectionFields.status} NOT IN (?, ?, ?)',
+      whereArgs: [providerId, BankConnectionStatus.revoked.code, BankConnectionStatus.disconnected.code, BankConnectionStatus.revocationPending.code],
+    );
+  }
+
+  Future<void> finalizeRemoteRevocation(int id) async => _finalizeDisconnect(id, BankConnectionStatus.revoked);
+
+  Future<void> disconnectLocally(int id) async => _finalizeDisconnect(id, BankConnectionStatus.disconnected);
+
+  Future<void> _finalizeDisconnect(int id, BankConnectionStatus status) async {
+    final db = await _database;
+    await db.transaction((txn) async {
+      final accounts = await txn.query(bankAccountTable, columns: [BankAccountFields.id], where: '${BankAccountFields.ebConnectionId} = ?', whereArgs: [id]);
+      for (final row in accounts) {
+        await _unlinkAccount(txn, id, row[BankAccountFields.id] as int);
+      }
+      final changed = await txn.update(
+        bankConnectionTable,
+        {BankConnectionFields.status: status.code, BankConnectionFields.remoteConnectionId: null, BankConnectionFields.pendingRemoteConnectionId: null, BankConnectionFields.pendingAuthorizationId: null, BankConnectionFields.pendingValidUntil: null, BankConnectionFields.updatedAt: DateTime.now().toUtc().toIso8601String()},
+        where: '${BankConnectionFields.id} = ?',
+        whereArgs: [id],
+      );
+      if (changed != 1) throw StateError('Bank connection $id not found');
+    });
+  }
+
+  Future<void> _unlinkAccount(DatabaseExecutor txn, int connectionId, int accountId) async {
+    await txn.delete(
+      bankAccountIdentityTable,
+      where:
+          '${BankAccountIdentityFields.connectionId} = ? AND '
+          '${BankAccountIdentityFields.bankAccountId} = ?',
+      whereArgs: [connectionId, accountId],
+    );
+    await txn.update(bankAccountTable, {BankAccountFields.ebAccountUid: null, BankAccountFields.ebConnectionId: null, BankAccountFields.identificationHash: null, BankAccountFields.identificationHashes: null, BankAccountFields.lastSyncAt: null}, where: '${BankAccountFields.id} = ?', whereArgs: [accountId]);
+  }
+}

--- a/lib/services/database/repositories/bank_reconciliation_exception.dart
+++ b/lib/services/database/repositories/bank_reconciliation_exception.dart
@@ -1,0 +1,13 @@
+// dart format width=400
+
+enum BankReconciliationFailure { missingStableIdentity, identityCollision, missingLocalAccount, invalidConnectionState }
+
+class BankReconciliationException implements Exception {
+  final BankReconciliationFailure failure;
+  final String message;
+
+  const BankReconciliationException(this.failure, this.message);
+
+  @override
+  String toString() => 'BankReconciliationException($failure, $message)';
+}

--- a/lib/services/database/sossoldi_database.dart
+++ b/lib/services/database/sossoldi_database.dart
@@ -10,11 +10,13 @@ import 'package:sqflite/sqflite.dart';
 
 // Models
 import '../../model/bank_account.dart';
+import '../../model/bank_connection.dart';
 import '../../model/budget.dart';
 import '../../model/category_transaction.dart';
 import '../../model/currency.dart';
 import '../../model/recurring_transaction.dart';
 import '../../model/transaction.dart';
+import '../banking/lifecycle/banking_backup_policy.dart';
 import 'migration_manager.dart';
 
 part 'sossoldi_database.g.dart';
@@ -30,7 +32,7 @@ class SossoldiDatabase {
 
   // Zero args constructor needed to extend this class
   SossoldiDatabase({String? dbName}) {
-    dbName = dbName ?? 'sossoldi.db';
+    if (dbName != null) SossoldiDatabase.dbName = dbName;
   }
 
   SossoldiDatabase._init();
@@ -110,7 +112,8 @@ class SossoldiDatabase {
           csvRow[0] = tableName; // Set table name
 
           // Fill in values for existing columns
-          row.forEach((col, value) {
+          final safeRow = BankingBackupPolicy.sanitizeForExport(tableName, row);
+          safeRow.forEach((col, value) {
             final int index = headers.indexOf(col);
             if (index != -1) {
               csvRow[index] = value?.toString() ?? '';
@@ -190,7 +193,10 @@ class SossoldiDatabase {
                   }
                 }
               }
-              await txn.insert(tableName, row);
+              await txn.insert(
+                tableName,
+                BankingBackupPolicy.sanitizeForRestore(tableName, row),
+              );
             }
             results[tableName] = true;
           } catch (e) {
@@ -377,6 +383,8 @@ class SossoldiDatabase {
         batch.execute('DROP TABLE IF EXISTS $categoryTransactionTable');
         batch.execute('DROP TABLE IF EXISTS $budgetTable');
         batch.execute('DROP TABLE IF EXISTS $currencyTable');
+        batch.execute('DROP TABLE IF EXISTS $bankAccountIdentityTable');
+        batch.execute('DROP TABLE IF EXISTS $bankConnectionTable');
         await batch.commit();
       });
     } catch (error) {
@@ -395,6 +403,8 @@ class SossoldiDatabase {
         batch.delete(categoryTransactionTable);
         batch.delete(budgetTable);
         batch.delete(currencyTable);
+        batch.delete(bankAccountIdentityTable);
+        batch.delete(bankConnectionTable);
         await batch.commit();
       });
     } catch (error) {

--- a/test/model/bank_account_test.dart
+++ b/test/model/bank_account_test.dart
@@ -106,7 +106,7 @@ void main() {
       sqflite_ffi.sqfliteFfiInit();
       sqflite_ffi.databaseFactory = sqflite_ffi.databaseFactoryFfi;
 
-      sossoldiDatabase = SossoldiDatabase(dbName: 'test.db');
+      sossoldiDatabase = SossoldiDatabase(dbName: 'bank_account_test.db');
       db = await sossoldiDatabase.database;
       await sossoldiDatabase.resetDatabase();
     });

--- a/test/model/bank_connection_test.dart
+++ b/test/model/bank_connection_test.dart
@@ -1,0 +1,36 @@
+// dart format width=400
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/model/bank_connection.dart';
+
+void main() {
+  test('legacy connection columns survive model naming changes and nullable copies', () {
+    final legacy = <String, Object?>{
+      'id': 7,
+      'aspspName': 'Legacy Bank',
+      'aspspCountry': 'IT',
+      'applicationId': 'app',
+      'sessionId': 'active-remote',
+      'pendingSessionId': 'pending-remote',
+      'pendingAuthorizationId': 'authorization',
+      'validUntil': '2026-11-01T00:00:00.000Z',
+      'pendingValidUntil': '2026-12-01T00:00:00.000Z',
+      'status': 'ACTIVE',
+      'psuType': 'personal',
+      'createdAt': '2026-09-01T00:00:00.000Z',
+      'updatedAt': '2026-09-12T00:00:00.000Z',
+    };
+    final restored = BankConnection.fromJson(legacy);
+    expect(restored.providerId, 'enable_banking');
+    expect(restored.institutionName, 'Legacy Bank');
+    expect(restored.institutionCountry, 'IT');
+    expect(restored.remoteConnectionId, 'active-remote');
+    expect(restored.pendingRemoteConnectionId, 'pending-remote');
+    expect(restored.toJson(update: true, clock: DateTime.utc(2026, 9, 12)), {...legacy, 'providerId': 'enable_banking'});
+    final cleared = restored.copy(providerId: 'alternative', pendingRemoteConnectionId: null);
+    expect(cleared.providerId, 'alternative');
+    expect(cleared.remoteConnectionId, 'active-remote');
+    expect(cleared.pendingRemoteConnectionId, isNull);
+    expect(cleared.toJson()['pendingSessionId'], isNull);
+  });
+}

--- a/test/model/transaction_test.dart
+++ b/test/model/transaction_test.dart
@@ -166,7 +166,7 @@ void main() {
     setUpAll(() async {
       sqflite_ffi.sqfliteFfiInit();
       sqflite_ffi.databaseFactory = sqflite_ffi.databaseFactoryFfi;
-      sossoldiDatabase = SossoldiDatabase(dbName: 'test.db');
+      sossoldiDatabase = SossoldiDatabase(dbName: 'transaction_test.db');
       db = await sossoldiDatabase.database;
       await sossoldiDatabase.clearDatabase();
     });

--- a/test/providers/banking_settings_provider_test.dart
+++ b/test/providers/banking_settings_provider_test.dart
@@ -1,0 +1,161 @@
+// dart format width=400
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/model/bank_connection.dart';
+import 'package:sossoldi/providers/banking_provider.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_api.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_auth.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_config.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_credentials_store.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_dependencies.dart';
+import 'package:sossoldi/services/banking/enable_banking/models/eb_application.dart';
+import 'package:sossoldi/services/database/migration_manager.dart';
+import 'package:sossoldi/services/database/repositories/bank_connection_repository.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _ApplicationApi extends EnableBankingApi {
+  _ApplicationApi() : super(auth: EnableBankingAuth(), store: const EnableBankingCredentialsStore());
+
+  Object? failure;
+  int calls = 0;
+
+  @override
+  Future<EbApplication> verifyApplicationCredentials({required String appId, required String privateKeyPem}) async {
+    calls++;
+    if (failure case final error?) throw error;
+    return EbApplication(name: 'Synthetic application', kid: appId, environment: EnableBankingEnvironment.production, active: true, services: ['AIS'], countries: ['IT'], redirectUrls: [kEbRedirectUri]);
+  }
+}
+
+class _Connections extends BankConnectionRepository {
+  _Connections(super.database) : super.withDatabase();
+
+  bool failWrites = false;
+
+  @override
+  Future<void> markOtherApplicationsReauthRequired(String applicationId, {required String providerId}) async {
+    if (failWrites) throw StateError('Synthetic database write failure');
+    await super.markOtherApplicationsReauthRequired(applicationId, providerId: providerId);
+  }
+
+  @override
+  Future<void> markAllReauthRequired({required String providerId}) async {
+    if (failWrites) throw StateError('Synthetic database write failure');
+    await super.markAllReauthRequired(providerId: providerId);
+  }
+}
+
+void main() {
+  const store = EnableBankingCredentialsStore();
+  late Database db;
+  late _Connections connections;
+  late _ApplicationApi api;
+  late ProviderContainer container;
+
+  setUp(() async {
+    FlutterSecureStorage.setMockInitialValues({});
+    sqfliteFfiInit();
+    final manager = MigrationManager();
+    db = await databaseFactoryFfi.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(version: manager.latestVersion, onCreate: (db, version) => manager.migrate(db, 0, version)),
+    );
+    connections = _Connections(db);
+    api = _ApplicationApi();
+    container = ProviderContainer(overrides: [enableBankingCredentialsStoreProvider.overrideWithValue(store), enableBankingApiProvider.overrideWithValue(api), bankConnectionRepositoryProvider.overrideWithValue(connections)]);
+    await container.read(enableBankingSettingsProvider.future);
+  });
+
+  tearDown(() async {
+    container.dispose();
+    await db.close();
+  });
+
+  Future<void> seedCredentials() => store.saveCredentials(
+    appId: 'old-app',
+    privateKeyPem: 'old-synthetic-key',
+    config: const EnableBankingConfig(appId: 'old-app', defaultCountry: 'IT', supportedCountries: ['IT'], redirectUrls: [kEbRedirectUri]),
+  );
+  Future<BankConnection> seedConnection(String applicationId, {String providerId = 'enable_banking'}) => connections.insert(BankConnection(providerId: providerId, applicationId: applicationId, institutionName: 'Synthetic bank', institutionCountry: 'IT', status: BankConnectionStatus.active));
+  Future<void> save() => container
+      .read(enableBankingSettingsProvider.notifier)
+      .save(
+        appId: 'new-app',
+        privateKeyPem: 'new-synthetic-key',
+        config: const EnableBankingConfig(appId: 'new-app', defaultCountry: 'it'),
+      );
+
+  test('settings read the provider credential store', () async {
+    expect(await container.read(enableBankingSettingsProvider.notifier).hasCredentials(), isFalse);
+    await seedCredentials();
+    container.invalidate(enableBankingSettingsProvider);
+    expect((await container.read(enableBankingSettingsProvider.future))?.appId, 'old-app');
+    expect(await container.read(enableBankingSettingsProvider.notifier).hasCredentials(), isTrue);
+  });
+
+  test('verified save invalidates only other applications of the selected provider', () async {
+    await seedCredentials();
+    final old = await seedConnection('old-app');
+    final same = await seedConnection('new-app');
+    final otherProvider = await seedConnection('old-app', providerId: 'alternative');
+    await save();
+    expect(api.calls, 1);
+    final saved = container.read(enableBankingSettingsProvider).requireValue!;
+    expect(saved.appId, 'new-app');
+    expect(saved.defaultCountry, 'IT');
+    expect(saved.supportedCountries, ['IT']);
+    expect((await store.readCredentials())?.privateKeyPem, 'new-synthetic-key');
+    expect((await connections.selectById(old.id!)).status, BankConnectionStatus.reauthRequired);
+    expect((await connections.selectById(same.id!)).status, BankConnectionStatus.active);
+    expect((await connections.selectById(otherProvider.id!)).status, BankConnectionStatus.active);
+  });
+
+  test('database failure restores the complete previous credential set', () async {
+    await seedCredentials();
+    final previous = await store.readCredentials();
+    connections.failWrites = true;
+    await save();
+    expect(container.read(enableBankingSettingsProvider).error, isA<StateError>());
+    final restored = await store.readCredentials();
+    expect(restored?.config.toJson(), previous!.config.toJson());
+    expect(restored?.privateKeyPem, previous.privateKeyPem);
+  });
+
+  test('failed first save removes the new credentials when there was no previous set', () async {
+    connections.failWrites = true;
+    await save();
+    expect(container.read(enableBankingSettingsProvider).hasError, isTrue);
+    expect(await store.readCredentials(), isNull);
+  });
+
+  test('verification failure leaves credentials and consent state unchanged', () async {
+    await seedCredentials();
+    final connection = await seedConnection('old-app');
+    api.failure = StateError('Synthetic verification failure');
+    await save();
+    expect(container.read(enableBankingSettingsProvider).hasError, isTrue);
+    expect((await store.readCredentials())?.config.appId, 'old-app');
+    expect((await connections.selectById(connection.id!)).status, BankConnectionStatus.active);
+  });
+
+  test('clear invalidates only the selected provider before removing its credentials', () async {
+    await seedCredentials();
+    final connection = await seedConnection('old-app');
+    final otherProvider = await seedConnection('old-app', providerId: 'alternative');
+    await container.read(enableBankingSettingsProvider.notifier).clear();
+    expect(container.read(enableBankingSettingsProvider).requireValue, isNull);
+    expect(await store.readCredentials(), isNull);
+    expect((await connections.selectById(connection.id!)).status, BankConnectionStatus.reauthRequired);
+    expect((await connections.selectById(otherProvider.id!)).status, BankConnectionStatus.active);
+  });
+
+  test('clear preserves credentials when invalidating consents fails', () async {
+    await seedCredentials();
+    connections.failWrites = true;
+    await container.read(enableBankingSettingsProvider.notifier).clear();
+    expect(container.read(enableBankingSettingsProvider).hasError, isTrue);
+    expect((await store.readCredentials())?.config.appId, 'old-app');
+  });
+}

--- a/test/services/banking/bank_callback_validation_test.dart
+++ b/test/services/banking/bank_callback_validation_test.dart
@@ -1,0 +1,46 @@
+// dart format width=400
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/services/banking/lifecycle/bank_deeplink_service.dart';
+
+void main() {
+  for (final value in [
+    'https://eb-callback?code=c&state=s',
+    'sossoldi://wrong?code=c&state=s',
+    'sossoldi://eb-callback/path?code=c&state=s',
+    'sossoldi://eb-callback:123?code=c&state=s',
+    'sossoldi://eb-callback?code=c&state=s&state=s',
+    'sossoldi://eb-callback?code=c&code=d&state=s',
+    'sossoldi://eb-callback?code=c&state=s&error=denied',
+    'sossoldi://eb-callback?code=&state=s',
+    'sossoldi://eb-callback?code=%20&state=s',
+    'sossoldi://eb-callback?state=s',
+    'sossoldi://eb-callback?code=c',
+    'sossoldi://eb-callback?code=c&state=',
+    'sossoldi://eb-callback?code=c&state=s#fragment',
+    'sossoldi://user@eb-callback?code=c&state=s',
+    'sossoldi://eb-callback?error=denied&error=denied&state=s',
+    'sossoldi://eb-callback?error=&state=s',
+    'sossoldi://eb-callback?error=denied&state=s&error_description=a&error_description=b',
+  ]) {
+    test('rejects malformed callback before lifecycle dispatch: $value', () {
+      expect(BankDeeplinkService.parse(Uri.parse(value)), isNull);
+    });
+  }
+
+  test('extracts the code and state for lifecycle validation without changing them', () {
+    final callback = BankDeeplinkService.parse(Uri.parse('sossoldi://eb-callback?code=a%2Bb%2Fc&state=persisted-state'))!;
+    expect(callback.code, 'a+b/c');
+    expect(callback.state, 'persisted-state');
+    expect(callback.error, isNull);
+  });
+
+  test('preserves cancellation callbacks for lifecycle cleanup', () {
+    final callback = BankDeeplinkService.parse(Uri.parse('sossoldi://eb-callback?error=access_denied&error_description=Cancelled&state=persisted-state'))!;
+    expect(callback.code, isNull);
+    expect(callback.state, 'persisted-state');
+    expect(callback.error, 'access_denied');
+    expect(callback.errorDescription, 'Cancelled');
+    expect(callback.isSuccess, isFalse);
+  });
+}

--- a/test/services/banking/bank_consent_lifecycle_service_test.dart
+++ b/test/services/banking/bank_consent_lifecycle_service_test.dart
@@ -1,0 +1,291 @@
+// dart format width=400
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/model/bank_connection.dart';
+import 'package:sossoldi/services/banking/bank_authorization_context.dart';
+import 'package:sossoldi/services/banking/bank_consent_service.dart';
+import 'package:sossoldi/services/banking/bank_institution.dart';
+import 'package:sossoldi/services/banking/bank_institution_directory.dart';
+import 'package:sossoldi/services/banking/banking_authorization.dart';
+import 'package:sossoldi/services/banking/banking_connection.dart';
+import 'package:sossoldi/services/banking/banking_exception.dart';
+import 'package:sossoldi/services/banking/banking_reference.dart';
+import 'package:sossoldi/services/banking/lifecycle/bank_authorization_callback.dart';
+import 'package:sossoldi/services/banking/lifecycle/bank_consent_lifecycle_service.dart';
+import 'package:sossoldi/services/banking/lifecycle/pending_bank_authorization.dart';
+import 'package:sossoldi/services/banking/lifecycle/pending_bank_authorization_store.dart';
+import 'package:sossoldi/services/database/migration_manager.dart';
+import 'package:sossoldi/services/database/repositories/bank_connection_repository.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _MemoryPendingStore implements PendingBankAuthorizationStore {
+  PendingBankAuthorization? value;
+
+  @override
+  Future<void> clear() async => value = null;
+
+  @override
+  Future<PendingBankAuthorization?> read() async => value;
+
+  @override
+  Future<void> save(PendingBankAuthorization pending) async => value = pending;
+}
+
+class _FakeApi implements BankConsentService, BankInstitutionDirectory {
+  List<BankInstitution> aspsps = [];
+  Object? createFailure;
+  Object? deleteFailure;
+  Object? getSessionFailure;
+  DateTime validUntil = DateTime.utc(2026, 10, 1);
+  BankingConnectionStatus sessionStatus = BankingConnectionStatus.active;
+  int createCalls = 0;
+  int startCalls = 0;
+  int deleteCalls = 0;
+  DateTime? requestedValidUntil;
+
+  @override
+  Future<List<BankInstitution>> getInstitutions({String? country, BankingCustomerType customerType = BankingCustomerType.personal}) async => aspsps;
+
+  @override
+  Future<BankingAuthorization> startAuthorization(BankingAuthorizationRequest request) async {
+    startCalls++;
+    requestedValidUntil = request.validUntil;
+    return BankingAuthorization(providerId: 'alternative', uri: Uri.parse('https://bank.example/authorize'), authorizationId: 'authorization-id');
+  }
+
+  BankingConnection connection(String id) => BankingConnection(
+    reference: BankingConnectionReference(providerId: 'alternative', remoteId: id),
+    institution: bank(),
+    validUntil: validUntil,
+    status: sessionStatus,
+    accounts: [],
+  );
+
+  @override
+  Future<BankingConnectionResult> createConnection(String code) async {
+    createCalls++;
+    if (createFailure case final failure?) throw failure;
+    return BankingConnectionResult(connection: connection('session-new'), accounts: []);
+  }
+
+  @override
+  Future<BankingConnection> getConnection(BankingConnectionReference reference) async {
+    expect(reference.providerId, 'alternative');
+    if (getSessionFailure case final failure?) throw failure;
+    return connection(reference.remoteId);
+  }
+
+  @override
+  Future<void> revokeConnection(BankingConnectionReference reference) async {
+    expect(reference.providerId, 'alternative');
+    deleteCalls++;
+    if (deleteFailure case final failure?) throw failure;
+  }
+}
+
+BankInstitution bank({String name = 'Test Bank', String country = 'IT', Set<BankingCustomerType> customerTypes = const {BankingCustomerType.personal}, Duration? maximumConsentDuration}) => BankInstitution(providerId: 'alternative', id: '$country:$name', name: name, country: country, customerTypes: customerTypes, maximumConsentDuration: maximumConsentDuration);
+
+void main() {
+  late Database db;
+  late BankConnectionRepository repository;
+  BankAuthorizationContext context = const BankAuthorizationContext(providerId: 'alternative', applicationId: 'app-id', redirectUri: 'sossoldi://eb-callback');
+  late _MemoryPendingStore pending;
+  late _FakeApi api;
+  final now = DateTime.utc(2026, 9, 1, 12);
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    context = const BankAuthorizationContext(providerId: 'alternative', applicationId: 'app-id', redirectUri: 'sossoldi://eb-callback');
+    final manager = MigrationManager();
+    db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(version: manager.latestVersion, onCreate: (database, version) => manager.migrate(database, 0, version)),
+    );
+    repository = BankConnectionRepository.withDatabase(db);
+    pending = _MemoryPendingStore();
+    api = _FakeApi();
+    api.aspsps = [
+      bank(name: 'Test Bank', country: 'IT', customerTypes: {BankingCustomerType.personal}, maximumConsentDuration: const Duration(seconds: 86400)),
+    ];
+  });
+
+  tearDown(() => db.close());
+
+  BankConsentLifecycleService service() => BankConsentLifecycleService(consent: api, institutions: api, readContext: () async => context, pendingStore: pending, connections: repository, clock: () => now, callbackSupported: () => true);
+
+  test('reconnect reloads metadata and clamps requested validity', () async {
+    final connection = await repository.insert(BankConnection(providerId: 'alternative', institutionName: 'Test Bank', institutionCountry: 'IT', applicationId: 'app-id', remoteConnectionId: 'old-session', validUntil: now.add(const Duration(days: 1)), status: BankConnectionStatus.active));
+
+    final attempt = await service().startAuthorization(
+      bank(name: 'Test Bank', country: 'IT', customerTypes: {BankingCustomerType.personal}, maximumConsentDuration: const Duration(seconds: 7776000)),
+      reconnectConnectionId: connection.id,
+    );
+
+    expect(api.requestedValidUntil, now.add(const Duration(days: 1)));
+
+    expect(attempt.url.scheme, 'https');
+    expect(pending.value?.reconnectConnectionId, connection.id);
+  });
+
+  test('cold-start callback stages session and duplicate is idempotent', () async {
+    await service().startAuthorization(api.aspsps.single);
+    final state = pending.value!.state;
+
+    final restarted = service();
+    final first = await restarted.completeCallback(BankAuthorizationCallback(code: 'code', state: state));
+    final duplicate = await restarted.completeCallback(BankAuthorizationCallback(code: 'code', state: state));
+
+    expect(first.connection.status, BankConnectionStatus.awaitingImport);
+    expect(first.connection.remoteConnectionId, isNull);
+    expect(first.connection.pendingRemoteConnectionId, 'session-new');
+    expect(duplicate.connection.id, first.connection.id);
+    expect(api.createCalls, 1);
+    expect(pending.value?.phase, PendingAuthorizationPhase.connectionStaged);
+    expect((await restarted.resumeAwaitingImports()).single.connection.id, first.connection.id);
+  });
+
+  test('failed staged reconnect keeps the previous session active', () async {
+    final connection = await repository.insert(BankConnection(providerId: 'alternative', institutionName: 'Test Bank', institutionCountry: 'IT', applicationId: 'app-id', remoteConnectionId: 'session-old', validUntil: now.add(const Duration(days: 1)), status: BankConnectionStatus.active));
+    await service().startAuthorization(api.aspsps.single, reconnectConnectionId: connection.id);
+    await service().completeCallback(BankAuthorizationCallback(code: 'code', state: pending.value!.state));
+    api.sessionStatus = BankingConnectionStatus.expired;
+
+    expect(await service().resumeAwaitingImports(), isEmpty);
+
+    final restored = await repository.selectById(connection.id!);
+    expect(restored.status, BankConnectionStatus.active);
+    expect(restored.remoteConnectionId, 'session-old');
+    expect(restored.pendingRemoteConnectionId, isNull);
+    expect(pending.value, isNull);
+  });
+
+  test('retryable callback failure remains pending and can be retried', () async {
+    await service().startAuthorization(api.aspsps.single);
+    final callback = BankAuthorizationCallback(code: 'code', state: pending.value!.state);
+    api.createFailure = const BankingException(providerId: 'alternative', failure: BankingFailure.unavailable);
+
+    expect(await service().handleCallback(callback), BankCallbackDisposition.retryable);
+    expect(pending.value, isNotNull);
+    api.createFailure = null;
+    expect(await service().handleCallback(callback), BankCallbackDisposition.terminal);
+    expect(api.createCalls, 2);
+  });
+
+  test('duplicate authorization start reuses one pending attempt', () async {
+    final first = await service().startAuthorization(api.aspsps.single);
+    final second = await service().startAuthorization(api.aspsps.single);
+
+    expect(second.url, first.url);
+    expect(second.consentValidUntil, first.consentValidUntil);
+    expect(api.startCalls, 1);
+  });
+
+  test('authorization uses the default validity when no limit exists', () async {
+    await service().startAuthorization(bank(name: 'Test Bank', country: 'IT', customerTypes: {BankingCustomerType.personal}));
+
+    expect(api.requestedValidUntil, now.add(const Duration(days: 90)));
+  });
+
+  test('business-only banks are rejected before authorization', () async {
+    await expectLater(() => service().startAuthorization(bank(name: 'Corporate Bank', country: 'IT', customerTypes: {BankingCustomerType.business})), throwsA(isA<BankingException>().having((error) => error.failure, 'kind', BankingFailure.rejected)));
+    expect(api.startCalls, 0);
+  });
+
+  test('expired and mismatched callbacks never exchange the code', () async {
+    await service().startAuthorization(api.aspsps.single);
+    final state = pending.value!.state;
+
+    await expectLater(() => service().completeCallback(const BankAuthorizationCallback(code: 'code', state: 'wrong')), throwsA(isA<BankingException>()));
+    expect(api.createCalls, 0);
+    pending.value = PendingBankAuthorization(providerId: 'alternative', state: state, authorizationId: 'authorization-id', authorizationUrl: 'https://bank.example/authorize', applicationId: 'app-id', institutionName: 'Test Bank', institutionCountry: 'IT', redirectUri: 'sossoldi://eb-callback', expiresAt: now, consentValidUntil: now.add(const Duration(days: 1)));
+    await expectLater(() => service().completeCallback(BankAuthorizationCallback(code: 'code', state: state)), throwsA(isA<BankingException>().having((error) => error.failure, 'kind', BankingFailure.connectionExpired)));
+    expect(pending.value, isNull);
+  });
+
+  test('failed browser launch preserves retry URL until explicit cancel', () async {
+    await service().startAuthorization(api.aspsps.single);
+    final url = Uri.parse(pending.value!.authorizationUrl);
+
+    final result = await service().launchAuthorization(url, launcher: (_) async => false);
+
+    expect(result.opened, isFalse);
+    expect(result.url, url);
+    expect(pending.value, isNotNull);
+    await service().cancelAuthorization();
+    expect(pending.value, isNull);
+  });
+
+  test('retryable revocation stays pending while not-found finalizes', () async {
+    final connection = await repository.insert(BankConnection(providerId: 'alternative', institutionName: 'Test Bank', institutionCountry: 'IT', applicationId: 'app-id', remoteConnectionId: 'session', validUntil: now.add(const Duration(days: 1)), status: BankConnectionStatus.active));
+    for (final kind in const [BankingFailure.unavailable, BankingFailure.rateLimited, BankingFailure.authentication, BankingFailure.forbidden]) {
+      api.deleteFailure = BankingException(providerId: 'alternative', failure: kind);
+      await expectLater(() => service().revoke(connection), throwsA(anything));
+      expect((await repository.selectById(connection.id!)).status, BankConnectionStatus.revocationPending);
+    }
+
+    api.deleteFailure = const BankingException(providerId: 'alternative', failure: BankingFailure.notFound);
+    await service().revoke(await repository.selectById(connection.id!));
+    expect((await repository.selectById(connection.id!)).status, BankConnectionStatus.revoked);
+  });
+
+  test('confirmed remote revocation finalizes the connection', () async {
+    final connection = await repository.insert(BankConnection(providerId: 'alternative', institutionName: 'Test Bank', institutionCountry: 'IT', applicationId: 'app-id', remoteConnectionId: 'session', validUntil: now.add(const Duration(days: 1)), status: BankConnectionStatus.active));
+
+    await service().revoke(connection);
+
+    expect(api.deleteCalls, 1);
+    expect((await repository.selectById(connection.id!)).status, BankConnectionStatus.revoked);
+  });
+
+  test('application auth error does not masquerade as expired session', () async {
+    final connection = await repository.insert(BankConnection(providerId: 'alternative', institutionName: 'Test Bank', institutionCountry: 'IT', applicationId: 'app-id', remoteConnectionId: 'session', validUntil: now.add(const Duration(days: 1)), status: BankConnectionStatus.active));
+    api.getSessionFailure = const BankingException(providerId: 'alternative', failure: BankingFailure.authentication);
+
+    final status = await service().refreshConnectionState(connection);
+
+    expect(status, BankConnectionStatus.reauthRequired);
+  });
+
+  test('unsupported platform is rejected before network or pending state', () async {
+    final unsupported = BankConsentLifecycleService(consent: api, institutions: api, readContext: () async => context, pendingStore: pending, connections: repository, callbackSupported: () => false);
+
+    await expectLater(() => unsupported.startAuthorization(api.aspsps.single), throwsA(isA<BankingException>()));
+    expect(pending.value, isNull);
+  });
+  for (final changed in [const BankAuthorizationContext(providerId: 'other', applicationId: 'app-id', redirectUri: 'sossoldi://eb-callback'), const BankAuthorizationContext(providerId: 'alternative', applicationId: 'rotated', redirectUri: 'sossoldi://eb-callback'), const BankAuthorizationContext(providerId: 'alternative', applicationId: 'app-id', redirectUri: 'https://example.com/callback')]) {
+    test('pending callback rejects changed context ${changed.providerId}/${changed.applicationId}/${changed.redirectUri}', () async {
+      await service().startAuthorization(api.aspsps.single);
+      final callback = BankAuthorizationCallback(code: 'code', state: pending.value!.state);
+      context = changed;
+      await expectLater(service().completeCallback(callback), throwsA(isA<BankingException>().having((error) => error.failure, 'failure', BankingFailure.authentication)));
+      expect(api.createCalls, 0);
+      expect(await repository.selectAll(), isEmpty);
+    });
+  }
+
+  test('foreign institution is rejected before starting authorization', () async {
+    final foreign = BankInstitution(providerId: 'other', id: 'bank', name: 'Test Bank', country: 'IT', customerTypes: {BankingCustomerType.personal});
+    await expectLater(service().startAuthorization(foreign), throwsA(isA<BankingException>()));
+    expect(api.startCalls, 0);
+    expect(pending.value, isNull);
+  });
+
+  test('active staged consent with elapsed validity is rejected on resume', () async {
+    await service().startAuthorization(api.aspsps.single);
+    final staged = await service().completeCallback(BankAuthorizationCallback(code: 'code', state: pending.value!.state));
+    api.validUntil = now;
+    expect(await service().resumeAwaitingImports(), isEmpty);
+    expect((await repository.selectById(staged.connection.id!)).status, BankConnectionStatus.expired);
+  });
+
+  test('credential mismatch cannot revoke a connection through another application', () async {
+    final connection = await repository.insert(const BankConnection(providerId: 'alternative', institutionName: 'Test Bank', institutionCountry: 'IT', applicationId: 'old-app', remoteConnectionId: 'session', status: BankConnectionStatus.active));
+    await expectLater(service().revoke(connection), throwsA(isA<BankingException>()));
+    expect(api.deleteCalls, 0);
+    expect((await repository.selectById(connection.id!)).remoteConnectionId, 'session');
+  });
+}

--- a/test/services/banking/bank_deeplink_service_test.dart
+++ b/test/services/banking/bank_deeplink_service_test.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/services/banking/lifecycle/bank_authorization_callback.dart';
+import 'package:sossoldi/services/banking/lifecycle/bank_deeplink_service.dart';
+
+class _Source implements UriLinkSource {
+  final controller = StreamController<Uri>.broadcast();
+  Uri? initial;
+  Object? initialError;
+
+  @override
+  Stream<Uri> get uriStream => controller.stream;
+
+  @override
+  Future<Uri?> getInitialUri() async {
+    if (initialError case final error?) throw error;
+    return initial;
+  }
+}
+
+void main() {
+  test(
+    'strictly accepts only the configured callback scheme host and path',
+    () {
+      expect(
+        BankDeeplinkService.parse(
+          Uri.parse('sossoldi://eb-callback?code=a&state=b'),
+        )?.code,
+        'a',
+      );
+      expect(
+        BankDeeplinkService.parse(
+          Uri.parse('https://eb-callback?code=a&state=b'),
+        ),
+        isNull,
+      );
+      expect(
+        BankDeeplinkService.parse(
+          Uri.parse('sossoldi://eb-callback/other?code=a&state=b'),
+        ),
+        isNull,
+      );
+    },
+  );
+
+  test(
+    'cold-start link is retried after retryable result then consumed',
+    () async {
+      final source = _Source()
+        ..initial = Uri.parse('sossoldi://eb-callback?code=a&state=b');
+      final service = BankDeeplinkService(source: source);
+      var calls = 0;
+
+      await service.start((callback) async {
+        calls++;
+        return calls == 1
+            ? BankCallbackDisposition.retryable
+            : BankCallbackDisposition.terminal;
+      });
+      source.controller.add(source.initial!);
+      await Future<void>.delayed(Duration.zero);
+      source.controller.add(source.initial!);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(calls, 2);
+      await service.dispose();
+      await source.controller.close();
+    },
+  );
+
+  test('plugin and callback failures are observable and retryable', () async {
+    final source = _Source()..initialError = StateError('plugin failed');
+    final service = BankDeeplinkService(source: source);
+    final errors = <Object>[];
+
+    await service.start(
+      (callback) async => throw TypeError(),
+      onError: (error) async => errors.add(error),
+    );
+    source.controller.add(Uri.parse('sossoldi://eb-callback?code=a&state=b'));
+    await Future<void>.delayed(Duration.zero);
+
+    expect(errors, hasLength(2));
+    await service.dispose();
+    await source.controller.close();
+  });
+}

--- a/test/services/banking/banking_backup_policy_test.dart
+++ b/test/services/banking/banking_backup_policy_test.dart
@@ -1,0 +1,28 @@
+// dart format width=400
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/model/bank_account.dart';
+import 'package:sossoldi/model/bank_connection.dart';
+import 'package:sossoldi/services/banking/lifecycle/banking_backup_policy.dart';
+
+void main() {
+  test('export redacts usable sessions and transient account identifiers', () {
+    final connection = BankingBackupPolicy.sanitizeForExport(bankConnectionTable, {BankConnectionFields.remoteConnectionId: 'secret-session', BankConnectionFields.pendingRemoteConnectionId: 'pending-session', BankConnectionFields.pendingAuthorizationId: 'authorization', BankConnectionFields.status: BankConnectionStatus.active.code});
+    final account = BankingBackupPolicy.sanitizeForExport(bankAccountTable, {BankAccountFields.ebAccountUid: 'session-account-uid', BankAccountFields.lastSyncAt: '2026-09-01T00:00:00.000Z', BankAccountFields.identificationHash: 'stable-hash'});
+
+    expect(connection[BankConnectionFields.remoteConnectionId], isNull);
+    expect(connection[BankConnectionFields.pendingRemoteConnectionId], isNull);
+    expect(connection[BankConnectionFields.pendingAuthorizationId], isNull);
+    expect(connection[BankConnectionFields.status], BankConnectionStatus.reauthRequired.code);
+    expect(account[BankAccountFields.ebAccountUid], isNull);
+    expect(account[BankAccountFields.lastSyncAt], isNull);
+    expect(account[BankAccountFields.identificationHash], 'stable-hash');
+  });
+
+  test('restore never trusts active state or session values from a CSV', () {
+    final restored = BankingBackupPolicy.sanitizeForRestore(bankConnectionTable, {BankConnectionFields.remoteConnectionId: 'attacker-session', BankConnectionFields.status: BankConnectionStatus.active.code});
+
+    expect(restored[BankConnectionFields.remoteConnectionId], isNull);
+    expect(restored[BankConnectionFields.status], BankConnectionStatus.reauthRequired.code);
+  });
+}

--- a/test/services/banking/banking_boundary_test.dart
+++ b/test/services/banking/banking_boundary_test.dart
@@ -4,14 +4,14 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:sossoldi/providers/banking_provider.dart';
 import 'package:sossoldi/services/banking/bank_institution.dart';
-import 'package:sossoldi/services/banking/banking_exception.dart';
 import 'package:sossoldi/services/banking/bank_institution_directory.dart' as domain;
+import 'package:sossoldi/services/banking/banking_exception.dart';
 import 'package:sossoldi/services/banking/banking_provider.dart';
 import 'package:sossoldi/services/banking/enable_banking/enable_banking_api.dart';
 import 'package:sossoldi/services/banking/enable_banking/enable_banking_auth.dart';
@@ -109,6 +109,27 @@ void main() {
     for (final entity in Directory('lib').listSync(recursive: true).whereType<File>()) {
       if (!entity.path.endsWith('.dart') || entity.path.endsWith('.g.dart') || entity.path.contains('/banking/enable_banking/') || entity.path == 'lib/providers/banking_provider.dart') continue;
       expect(RegExp(r'''(?:import|export)\s+['"][^'"]*enable_banking/''').hasMatch(entity.readAsStringSync()), isFalse, reason: entity.path);
+    }
+  });
+  test('the Enable Banking module never imports application lifecycle or persistence', () {
+    for (final file in Directory('lib/services/banking/enable_banking').listSync(recursive: true).whereType<File>()) {
+      if (!file.path.endsWith('.dart') || file.path.endsWith('.g.dart')) continue;
+      final imports = RegExp(r'''(?:import|export)\s+['"]([^'"]+)['"]''').allMatches(file.readAsStringSync()).map((match) => match.group(1)!);
+      for (final path in imports) {
+        final resolved = path.startsWith('package:sossoldi/') ? Uri.file('lib/${path.substring('package:sossoldi/'.length)}') : Uri.file(file.path).resolve(path);
+        expect(resolved.path.contains('/database/') || resolved.path.contains('/providers/') || resolved.path.contains('/lifecycle/'), isFalse, reason: '${file.path} -> $path');
+      }
+    }
+  });
+
+  test('application callbacks are independent of provider DTOs and deep-link transport', () {
+    final callback = File('lib/services/banking/lifecycle/bank_authorization_callback.dart').readAsStringSync();
+    expect(RegExp(r"(?:import|export)\s").hasMatch(callback), isFalse);
+    final lifecycle = File('lib/services/banking/lifecycle/bank_consent_lifecycle_service.dart').readAsStringSync();
+    expect(lifecycle.contains('bank_deeplink_service.dart'), isFalse);
+    for (final file in Directory('lib/services/banking/lifecycle').listSync().whereType<File>()) {
+      if (!file.path.endsWith('.dart')) continue;
+      expect(RegExp(r'EnableBanking|enableBanking').hasMatch(file.readAsStringSync()), isFalse, reason: file.path);
     }
   });
 }

--- a/test/services/banking/banking_platform_support_test.dart
+++ b/test/services/banking/banking_platform_support_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/services/banking/lifecycle/banking_platform_support.dart';
+
+void main() {
+  test('feature-gates platforms without a reliable callback registration', () {
+    expect(
+      BankingPlatformSupport.supportsCallback(
+        platform: TargetPlatform.android,
+        isWeb: false,
+      ),
+      isTrue,
+    );
+    expect(
+      BankingPlatformSupport.supportsCallback(
+        platform: TargetPlatform.iOS,
+        isWeb: false,
+      ),
+      isTrue,
+    );
+    expect(
+      BankingPlatformSupport.supportsCallback(
+        platform: TargetPlatform.macOS,
+        isWeb: false,
+      ),
+      isTrue,
+    );
+    expect(
+      BankingPlatformSupport.supportsCallback(
+        platform: TargetPlatform.windows,
+        isWeb: false,
+      ),
+      isFalse,
+    );
+    expect(
+      BankingPlatformSupport.supportsCallback(
+        platform: TargetPlatform.linux,
+        isWeb: false,
+      ),
+      isFalse,
+    );
+    expect(
+      BankingPlatformSupport.supportsCallback(
+        platform: TargetPlatform.android,
+        isWeb: true,
+      ),
+      isFalse,
+    );
+  });
+}

--- a/test/services/banking/eb_models_test.dart
+++ b/test/services/banking/eb_models_test.dart
@@ -179,5 +179,13 @@ void main() {
 
       expect(() => EbSessionDetails.fromJson(json), throwsFormatException);
     });
+
+    test('account data tolerates a missing stable hash', () {
+      final account = EbSessionAccount.fromJson({'uid': 'session-only-uid'});
+
+      expect(account.uid, 'session-only-uid');
+      expect(account.identificationHash, isNull);
+      expect(account.identificationHashes, isEmpty);
+    });
   });
 }

--- a/test/services/banking/enable_banking_api_test.dart
+++ b/test/services/banking/enable_banking_api_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -26,10 +27,14 @@ class _FakeAuth extends EnableBankingAuth {
       'test-token';
 }
 
-EnableBankingApi _apiWith(MockClientHandler handler) => EnableBankingApi(
+EnableBankingApi _apiWith(
+  MockClientHandler handler, {
+  Duration timeout = const Duration(seconds: 30),
+}) => EnableBankingApi(
   auth: _FakeAuth(),
   store: const EnableBankingCredentialsStore(),
   client: MockClient(handler),
+  timeout: timeout,
 );
 
 http.Response _json(Object body, {int statusCode = 200}) => http.Response(
@@ -370,6 +375,120 @@ void main() {
             'isUnauthorized',
             isTrue,
           ),
+        ),
+      );
+    });
+
+    test('classifies session codes before generic HTTP status', () async {
+      final cases = {
+        'EXPIRED_SESSION': EnableBankingFailureKind.sessionExpired,
+        'REVOKED_SESSION': EnableBankingFailureKind.sessionRevoked,
+        'CLOSED_SESSION': EnableBankingFailureKind.sessionClosed,
+      };
+      for (final entry in cases.entries) {
+        final api = _apiWith(
+          (request) async => _json({
+            'error': {'code': entry.key, 'message': 'session failure'},
+          }, statusCode: 401),
+        );
+        await expectLater(
+          () => api.getBalances('account'),
+          throwsA(
+            isA<EnableBankingException>().having(
+              (error) => error.kind,
+              'kind',
+              entry.value,
+            ),
+          ),
+        );
+      }
+    });
+
+    test(
+      'distinguishes auth, rate limit, server and malformed response',
+      () async {
+        for (final entry in {
+          401: EnableBankingFailureKind.applicationAuthentication,
+          429: EnableBankingFailureKind.rateLimited,
+          503: EnableBankingFailureKind.server,
+        }.entries) {
+          final api = _apiWith(
+            (request) async => _json({}, statusCode: entry.key),
+          );
+          await expectLater(
+            () => api.getBalances('account'),
+            throwsA(
+              isA<EnableBankingException>().having(
+                (error) => error.kind,
+                'kind',
+                entry.value,
+              ),
+            ),
+          );
+        }
+        final malformed = _apiWith(
+          (request) async => http.Response('not-json', 200),
+        );
+        await expectLater(
+          () => malformed.getBalances('account'),
+          throwsA(
+            isA<EnableBankingException>().having(
+              (error) => error.kind,
+              'kind',
+              EnableBankingFailureKind.invalidResponse,
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'ignores non-string error codes without leaking a TypeError',
+      () async {
+        final api = _apiWith(
+          (request) async => _json({'error': 42}, statusCode: 503),
+        );
+
+        await expectLater(
+          () => api.getBalances('account'),
+          throwsA(
+            isA<EnableBankingException>().having(
+              (error) => error.kind,
+              'kind',
+              EnableBankingFailureKind.server,
+            ),
+          ),
+        );
+      },
+    );
+
+    test('forwards business discovery supported by the foundation', () async {
+      var calls = 0;
+      final api = _apiWith((request) async {
+        calls++;
+        return _json({'aspsps': []});
+      });
+
+      expect(await api.getAspsps(psuType: 'business'), isEmpty);
+      expect(calls, 1);
+    });
+
+    test('maps request timeout to a retryable typed failure', () async {
+      final api = _apiWith(
+        (request) => Completer<http.Response>().future,
+        timeout: const Duration(milliseconds: 1),
+      );
+
+      await expectLater(
+        () => api.getBalances('account'),
+        throwsA(
+          isA<EnableBankingException>()
+              .having(
+                (error) => error.kind,
+                'kind',
+                EnableBankingFailureKind.timeout,
+              )
+              .having((error) => error.isRetryable, 'isRetryable', isTrue),
         ),
       );
     });

--- a/test/services/banking/enable_banking_credentials_service_test.dart
+++ b/test/services/banking/enable_banking_credentials_service_test.dart
@@ -199,4 +199,57 @@ void main() {
       );
     },
   );
+
+  test('rejects malformed or lookalike custom callbacks', () async {
+    final service = EnableBankingCredentialsService(
+      api: _FakeApplicationApi(
+        const EbApplication(
+          name: 'Sossoldi',
+          kid: 'app-123',
+          environment: EnableBankingEnvironment.production,
+          redirectUrls: ['sossoldi://eb-callback/other'],
+          active: true,
+          countries: ['IT'],
+          services: ['AIS'],
+        ),
+      ),
+      store: const EnableBankingCredentialsStore(),
+    );
+
+    await expectLater(
+      () => service.saveVerifiedCredentials(
+        appId: 'app-123',
+        privateKeyPem: 'private-key',
+        redirectUri: 'sossoldi://eb-callback/other',
+      ),
+      throwsA(isA<EnableBankingException>()),
+    );
+  });
+
+  test(
+    'accepts only the versioned HTTPS relay when server-registered',
+    () async {
+      const relayApplication = EbApplication(
+        name: 'Sossoldi',
+        kid: 'app-123',
+        environment: EnableBankingEnvironment.production,
+        redirectUrls: [kEbRelayRedirectUri],
+        active: true,
+        countries: ['IT'],
+        services: ['AIS'],
+      );
+      final service = EnableBankingCredentialsService(
+        api: _FakeApplicationApi(relayApplication),
+        store: const EnableBankingCredentialsStore(),
+      );
+
+      final config = await service.saveVerifiedCredentials(
+        appId: 'app-123',
+        privateKeyPem: 'private-key',
+        redirectUri: kEbRelayRedirectUri,
+      );
+
+      expect(config.redirectUri, kEbRelayRedirectUri);
+    },
+  );
 }

--- a/test/services/banking/enable_banking_lifecycle_adapter_test.dart
+++ b/test/services/banking/enable_banking_lifecycle_adapter_test.dart
@@ -1,0 +1,139 @@
+// dart format width=400
+
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:sossoldi/model/bank_account.dart';
+import 'package:sossoldi/model/bank_connection.dart';
+import 'package:sossoldi/services/banking/banking_exception.dart';
+import 'package:sossoldi/services/banking/banking_reference.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_api.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_auth.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_config.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_credentials_store.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_dependencies.dart';
+import 'package:sossoldi/services/banking/enable_banking/enable_banking_provider.dart';
+import 'package:sossoldi/services/banking/lifecycle/bank_authorization_callback.dart';
+import 'package:sossoldi/services/banking/lifecycle/bank_consent_lifecycle_service.dart';
+import 'package:sossoldi/services/banking/lifecycle/pending_bank_authorization_store.dart';
+import 'package:sossoldi/services/database/migration_manager.dart';
+import 'package:sossoldi/services/database/repositories/bank_connection_repository.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+class _Auth extends EnableBankingAuth {
+  @override
+  Future<String> getValidToken(EnableBankingCredentialsStore store) async => 'synthetic';
+}
+
+void main() {
+  const store = EnableBankingCredentialsStore();
+  setUp(() => FlutterSecureStorage.setMockInitialValues({}));
+
+  test('foundation adapters preserve relay, staging, account identities and revocation through SQLite', () async {
+    sqfliteFfiInit();
+    final manager = MigrationManager();
+    final db = await databaseFactoryFfi.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(version: manager.latestVersion, onCreate: (db, version) => manager.migrate(db, 0, version)),
+    );
+    addTearDown(db.close);
+    await store.saveCredentials(
+      appId: 'app',
+      privateKeyPem: 'synthetic',
+      config: const EnableBankingConfig(appId: 'app', redirectUri: kEbRelayRedirectUri, redirectUrls: [kEbRelayRedirectUri]),
+    );
+    final requests = <String>[];
+    final remote = EnableBankingProvider(
+      EnableBankingApi(
+        auth: _Auth(),
+        store: store,
+        client: MockClient((request) async {
+          final route = '${request.method} ${request.url.path}';
+          requests.add(route);
+          final body = switch (route) {
+            'GET /aspsps' => {
+              'aspsps': [
+                {
+                  'name': 'Bank',
+                  'country': 'IT',
+                  'psu_types': ['personal'],
+                  'maximum_consent_validity': 86400,
+                },
+              ],
+            },
+            'POST /auth' => {'url': 'https://bank.example/consent', 'authorization_id': 'auth', 'psu_id_hash': 'psu'},
+            'POST /sessions' => {
+              'session_id': 'session',
+              'aspsp': {'name': 'Bank', 'country': 'IT'},
+              'psu_type': 'personal',
+              'access': {'valid_until': '2026-10-01T00:00:00Z'},
+              'accounts': [
+                {
+                  'uid': 'account',
+                  'identification_hash': ' primary ',
+                  'identification_hashes': ['alias', ''],
+                  'account_id': {'iban': 'IT00SYNTHETIC'},
+                },
+              ],
+            },
+            'GET /sessions/session' => {
+              'status': 'AUTHORIZED',
+              'aspsp': {'name': 'Bank', 'country': 'IT'},
+              'psu_type': 'personal',
+              'access': {'valid_until': '2026-10-01T00:00:00Z'},
+              'created': '2026-09-11T00:00:00Z',
+              'accounts': ['account'],
+              'accounts_data': [
+                {
+                  'uid': 'account',
+                  'identification_hashes': ['alias'],
+                },
+              ],
+            },
+            'DELETE /sessions/session' => <String, Object?>{},
+            _ => throw StateError('Unexpected request $route'),
+          };
+          if (route == 'POST /auth') {
+            final posted = jsonDecode(request.body) as Map<String, dynamic>;
+            expect(posted['redirect_url'], kEbRelayRedirectUri);
+            expect(posted['psu_type'], 'personal');
+          }
+          if (route == 'POST /sessions') expect(jsonDecode(request.body), {'code': ' code-preserved '});
+          return http.Response(jsonEncode(body), 200);
+        }),
+      ),
+    );
+    final repository = BankConnectionRepository.withDatabase(db);
+    BankConsentLifecycleService lifecycle() => BankConsentLifecycleService(consent: remote.consent, institutions: remote.institutions, readContext: () => readEnableBankingAuthorizationContext(store), pendingStore: const SecurePendingBankAuthorizationStore(), connections: repository, clock: () => DateTime.utc(2026, 9, 11), callbackSupported: () => true);
+    await lifecycle().startAuthorization((await remote.institutions.getInstitutions()).single);
+    final pending = await const SecurePendingBankAuthorizationStore().read();
+    final staged = await lifecycle().completeCallback(BankAuthorizationCallback(code: ' code-preserved ', state: pending!.state));
+    expect(staged.connection.providerId, 'enable_banking');
+    final resumed = (await lifecycle().resumeAwaitingImports()).single;
+    expect(resumed.details.accounts.single.identityKeys, {'alias'});
+    final active = await lifecycle().activateConnection(staged.connection.id!, [(remote: staged.createdConnection!.accounts.single, newAccount: const BankAccount(name: 'Imported', symbol: 'wallet', color: 1, startingValue: 0, active: true, countNetWorth: true, mainAccount: false, order: 0))]);
+    expect(active.status, BankConnectionStatus.active);
+    final account = (await db.query(bankAccountTable)).single;
+    expect(account[BankAccountFields.ebAccountUid], 'account');
+    final identities = await db.query(bankAccountIdentityTable);
+    expect(identities.map((row) => row[BankAccountIdentityFields.identificationHash]).toSet(), {'primary', 'alias'});
+    await lifecycle().revoke(active);
+    expect((await repository.selectById(active.id!)).status, BankConnectionStatus.revoked);
+    expect(requests.where((route) => route == 'POST /sessions'), hasLength(1));
+    expect(await const SecurePendingBankAuthorizationStore().read(), isNull);
+  });
+
+  for (final entry in {'EXPIRED_SESSION': BankingFailure.connectionExpired, 'REVOKED_SESSION': BankingFailure.connectionRevoked, 'CLOSED_SESSION': BankingFailure.connectionClosed}.entries) {
+    test('adapter preserves ${entry.key} independently of HTTP 401', () async {
+      final provider = EnableBankingProvider(EnableBankingApi(auth: _Auth(), store: store, client: MockClient((_) async => http.Response(jsonEncode({'error': entry.key}), 401))));
+      await expectLater(provider.consent.getConnection(const BankingConnectionReference(providerId: 'enable_banking', remoteId: 'session')), throwsA(isA<BankingException>().having((error) => error.failure, 'failure', entry.value)));
+    });
+  }
+
+  test('missing credentials are reported through the generic context boundary', () async {
+    await expectLater(readEnableBankingAuthorizationContext(store), throwsA(isA<BankingException>().having((error) => error.failure, 'failure', BankingFailure.authentication)));
+  });
+}

--- a/test/services/banking/enable_banking_relay_test.dart
+++ b/test/services/banking/enable_banking_relay_test.dart
@@ -1,0 +1,15 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('versioned HTTPS relay forwards the callback to the app scheme', () {
+    final relay = File(
+      'docs/enablebanking/eb-callback.html',
+    ).readAsStringSync();
+
+    expect(relay, contains("'sossoldi://eb-callback'"));
+    expect(relay, contains('window.location.search'));
+    expect(relay, isNot(contains('<script src=')));
+  });
+}

--- a/test/services/banking/pending_bank_authorization_store_test.dart
+++ b/test/services/banking/pending_bank_authorization_store_test.dart
@@ -1,0 +1,77 @@
+// dart format width=400
+
+import 'dart:convert';
+
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/services/banking/banking_exception.dart';
+import 'package:sossoldi/services/banking/lifecycle/pending_bank_authorization.dart';
+import 'package:sossoldi/services/banking/lifecycle/pending_bank_authorization_store.dart';
+
+void main() {
+  setUp(() => FlutterSecureStorage.setMockInitialValues({}));
+
+  test('legacy staged authorization keeps its storage keys and phase through a round trip', () async {
+    final legacy = <String, Object?>{
+      'version': 1,
+      'state': 'legacy-state',
+      'authorization_id': 'legacy-auth',
+      'authorization_url': 'https://bank.example/authorize',
+      'application_id': 'legacy-app',
+      'aspsp_name': 'Legacy Bank',
+      'aspsp_country': 'IT',
+      'redirect_uri': 'sossoldi://eb-callback',
+      'expires_at': '2026-09-12T10:15:00.000Z',
+      'consent_valid_until': '2026-12-01T00:00:00.000Z',
+      'reconnect_connection_id': 7,
+      'staged_connection_id': 9,
+      'phase': 'sessionStaged',
+    };
+    FlutterSecureStorage.setMockInitialValues({'eb_pending_authorization_v1': jsonEncode(legacy)});
+    const store = SecurePendingBankAuthorizationStore();
+    final restored = (await store.read())!;
+    expect(restored.providerId, 'enable_banking');
+    expect(restored.institutionName, 'Legacy Bank');
+    expect(restored.institutionCountry, 'IT');
+    expect(restored.phase, PendingAuthorizationPhase.connectionStaged);
+    expect(restored.stagedConnectionId, 9);
+    await store.save(restored);
+    final encoded = jsonDecode((await const FlutterSecureStorage().read(key: 'eb_pending_authorization_v1'))!) as Map<String, dynamic>;
+    expect(encoded, {...legacy, 'provider_id': 'enable_banking'});
+    expect((await store.read())!.phase, PendingAuthorizationPhase.connectionStaged);
+  });
+
+  test('persists every cold-start callback field in encrypted storage', () async {
+    const store = SecurePendingBankAuthorizationStore();
+    final pending = PendingBankAuthorization(
+      providerId: 'alternative',
+      state: 'csrf-state',
+      authorizationId: 'authorization-id',
+      authorizationUrl: 'https://bank.example/authorize',
+      applicationId: 'app-id',
+      institutionName: 'Test Bank',
+      institutionCountry: 'IT',
+      redirectUri: 'sossoldi://eb-callback',
+      expiresAt: DateTime.utc(2026, 9, 1, 12, 15),
+      consentValidUntil: DateTime.utc(2026, 12, 1),
+      reconnectConnectionId: 7,
+    );
+
+    await store.save(pending);
+    final restored = await const SecurePendingBankAuthorizationStore().read();
+
+    expect(restored?.providerId, 'alternative');
+    expect(PendingBankAuthorization.fromJson(pending.toJson()..remove('provider_id')).providerId, 'enable_banking');
+    expect(restored?.state, 'csrf-state');
+    expect(restored?.authorizationId, 'authorization-id');
+    expect(restored?.institutionName, 'Test Bank');
+    expect(restored?.reconnectConnectionId, 7);
+    expect(restored?.expiresAt, DateTime.utc(2026, 9, 1, 12, 15));
+  });
+
+  test('corrupted pending state is rejected instead of partially read', () async {
+    FlutterSecureStorage.setMockInitialValues({'eb_pending_authorization_v1': '{bad json'});
+
+    await expectLater(() => const SecurePendingBankAuthorizationStore().read(), throwsA(isA<BankingException>().having((error) => error.failure, 'kind', BankingFailure.invalidResponse)));
+  });
+}

--- a/test/services/database/migrations/add_bank_consent_lifecycle_test.dart
+++ b/test/services/database/migrations/add_bank_consent_lifecycle_test.dart
@@ -1,0 +1,119 @@
+// dart format width=400
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as path;
+import 'package:sossoldi/model/bank_account.dart';
+import 'package:sossoldi/model/bank_connection.dart';
+import 'package:sossoldi/model/base_entity.dart';
+import 'package:sossoldi/services/database/migration_manager.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  late String dbPath;
+  final manager = MigrationManager();
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() {
+    dbPath = path.join(Directory.systemTemp.path, 'sossoldi_bank_consent_migration_test.db');
+  });
+
+  tearDown(() async {
+    await databaseFactory.deleteDatabase(dbPath);
+  });
+
+  test('v8 upgrade namespaces existing sessions without changing their IDs', () async {
+    final v8 = await databaseFactory.openDatabase(dbPath, options: OpenDatabaseOptions(version: 8, onCreate: (db, version) => manager.migrate(db, 0, version)));
+    final row = {BankConnectionFields.institutionName: 'Bank', BankConnectionFields.institutionCountry: 'IT', BankConnectionFields.applicationId: 'app', BankConnectionFields.remoteConnectionId: 'session', BankConnectionFields.status: 'ACTIVE', BankConnectionFields.createdAt: '2026-09-01T00:00:00Z', BankConnectionFields.updatedAt: '2026-09-01T00:00:00Z'};
+    final original = await v8.insert(bankConnectionTable, row);
+    await v8.close();
+    final upgraded = await databaseFactory.openDatabase(
+      dbPath,
+      options: OpenDatabaseOptions(version: manager.latestVersion, onUpgrade: manager.migrate),
+    );
+    try {
+      final restored = BankConnection.fromJson((await upgraded.query(bankConnectionTable)).single);
+      expect(restored.id, original);
+      expect(restored.providerId, 'enable_banking');
+      expect(restored.remoteConnectionId, 'session');
+      await upgraded.insert(bankConnectionTable, {...row, BankConnectionFields.providerId: 'alternative'});
+      await expectLater(upgraded.insert(bankConnectionTable, row), throwsA(isA<DatabaseException>()));
+      expect(await upgraded.query(bankConnectionTable), hasLength(2));
+    } finally {
+      await upgraded.close();
+    }
+  });
+
+  test('v7 upgrade preserves manual accounts and adds lifecycle schema', () async {
+    final v7 = await databaseFactory.openDatabase(dbPath, options: OpenDatabaseOptions(version: 7, onCreate: (db, version) => manager.migrate(db, 0, version)));
+    await v7.insert(bankAccountTable, {
+      BankAccountFields.name: 'Cash',
+      BankAccountFields.symbol: 'wallet',
+      BankAccountFields.color: 1,
+      BankAccountFields.startingValue: 25,
+      BankAccountFields.active: 1,
+      BankAccountFields.countNetWorth: 1,
+      BankAccountFields.mainAccount: 0,
+      BankAccountFields.order: 0,
+      BaseEntityFields.createdAt: '2026-01-01T00:00:00.000Z',
+      BaseEntityFields.updatedAt: '2026-01-01T00:00:00.000Z',
+    });
+    await v7.close();
+
+    final v8 = await databaseFactory.openDatabase(dbPath, options: OpenDatabaseOptions(version: 8, onUpgrade: manager.migrate));
+    final accountColumns = (await v8.rawQuery('PRAGMA table_info(`$bankAccountTable`)')).map((row) => row['name']);
+    expect(accountColumns, containsAll([BankAccountFields.ebAccountUid, BankAccountFields.ebConnectionId, BankAccountFields.identificationHash, BankAccountFields.identificationHashes, BankAccountFields.iban, BankAccountFields.lastSyncAt]));
+    expect(await v8.query(bankAccountTable), hasLength(1));
+    expect((await v8.query(bankAccountTable)).single[BankAccountFields.ebAccountUid], isNull);
+    expect((await v8.rawQuery("SELECT name FROM sqlite_master WHERE type = 'table'")).map((row) => row['name']), containsAll([bankConnectionTable, bankAccountIdentityTable]));
+    await v8.close();
+  });
+
+  test('fresh schema enforces stable hash uniqueness per connection', () async {
+    final db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(version: manager.latestVersion, onCreate: (database, version) => manager.migrate(database, 0, version)),
+    );
+    final now = '2026-01-01T00:00:00.000Z';
+    final connectionId = await db.insert(bankConnectionTable, {BankConnectionFields.institutionName: 'Bank', BankConnectionFields.institutionCountry: 'IT', BankConnectionFields.applicationId: 'app', BankConnectionFields.status: BankConnectionStatus.awaitingImport.code, BankConnectionFields.psuType: 'personal', BankConnectionFields.createdAt: now, BankConnectionFields.updatedAt: now});
+    final first = await db.insert(bankAccountTable, _accountRow('First'));
+    final second = await db.insert(bankAccountTable, _accountRow('Second'));
+    await db.insert(bankAccountIdentityTable, {BankAccountIdentityFields.connectionId: connectionId, BankAccountIdentityFields.bankAccountId: first, BankAccountIdentityFields.identificationHash: 'stable-hash'});
+
+    await expectLater(() => db.insert(bankAccountIdentityTable, {BankAccountIdentityFields.connectionId: connectionId, BankAccountIdentityFields.bankAccountId: second, BankAccountIdentityFields.identificationHash: 'stable-hash'}), throwsA(isA<DatabaseException>()));
+    await db.close();
+  });
+
+  test('failed v8 upgrade rolls back every partial schema change', () async {
+    final v7 = await databaseFactory.openDatabase(dbPath, options: OpenDatabaseOptions(version: 7, onCreate: (db, version) => manager.migrate(db, 0, version)));
+    await v7.execute('CREATE TABLE sabotage (sessionId TEXT)');
+    await v7.execute('CREATE INDEX idx_bank_connection_session ON sabotage (sessionId)');
+    await v7.close();
+
+    await expectLater(() => databaseFactory.openDatabase(dbPath, options: OpenDatabaseOptions(version: 8, onUpgrade: manager.migrate)), throwsA(isA<DatabaseException>()));
+    final unchanged = await databaseFactory.openDatabase(dbPath, options: OpenDatabaseOptions(version: 7));
+    final tables = await unchanged.rawQuery("SELECT name FROM sqlite_master WHERE type = 'table'");
+    expect(tables.map((row) => row['name']), isNot(contains(bankConnectionTable)));
+    final columns = await unchanged.rawQuery('PRAGMA table_info(`$bankAccountTable`)');
+    expect(columns.map((row) => row['name']), isNot(contains(BankAccountFields.ebAccountUid)));
+    await unchanged.close();
+  });
+}
+
+Map<String, Object?> _accountRow(String name) => {
+  BankAccountFields.name: name,
+  BankAccountFields.symbol: 'wallet',
+  BankAccountFields.color: 1,
+  BankAccountFields.startingValue: 0,
+  BankAccountFields.active: 1,
+  BankAccountFields.countNetWorth: 1,
+  BankAccountFields.mainAccount: 0,
+  BankAccountFields.order: 0,
+  BaseEntityFields.createdAt: '2026-01-01T00:00:00.000Z',
+  BaseEntityFields.updatedAt: '2026-01-01T00:00:00.000Z',
+};

--- a/test/services/database/repositories/bank_connection_repository_test.dart
+++ b/test/services/database/repositories/bank_connection_repository_test.dart
@@ -1,0 +1,158 @@
+// dart format width=400
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sossoldi/model/bank_account.dart';
+import 'package:sossoldi/model/bank_account_link.dart';
+import 'package:sossoldi/model/bank_connection.dart';
+import 'package:sossoldi/services/database/migration_manager.dart';
+import 'package:sossoldi/services/database/repositories/bank_connection_repository.dart';
+import 'package:sossoldi/services/database/repositories/bank_reconciliation_exception.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  late Database db;
+  late BankConnectionRepository repository;
+
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  setUp(() async {
+    final manager = MigrationManager();
+    db = await databaseFactory.openDatabase(
+      inMemoryDatabasePath,
+      options: OpenDatabaseOptions(version: manager.latestVersion, onCreate: (database, version) => manager.migrate(database, 0, version)),
+    );
+    repository = BankConnectionRepository.withDatabase(db);
+  });
+
+  tearDown(() => db.close());
+
+  test('same authorization ID remains distinct across providers and credential rotation', () async {
+    Future<BankConnection> stage(String provider) => repository.stageConnection(providerId: provider, authorizationId: 'same-auth', applicationId: 'same-app', institutionName: 'Bank', institutionCountry: 'IT', remoteConnectionId: 'same-session', validUntil: DateTime.utc(2027), psuType: 'personal');
+    final eb = await stage('enable_banking');
+    final alternative = await stage('alternative');
+    expect(eb.id, isNot(alternative.id));
+    expect((await stage('alternative')).id, alternative.id);
+    expect((await repository.findByPendingAuthorizationId('same-auth', providerId: 'alternative'))?.id, alternative.id);
+    await repository.markAllReauthRequired(providerId: 'enable_banking');
+    expect((await repository.selectById(eb.id!)).status, BankConnectionStatus.reauthRequired);
+    expect((await repository.selectById(alternative.id!)).status, BankConnectionStatus.awaitingImport);
+    await repository.markOtherApplicationsReauthRequired('rotated', providerId: 'enable_banking');
+    expect((await repository.selectById(alternative.id!)).status, BankConnectionStatus.awaitingImport);
+    await repository.markOtherApplicationsReauthRequired('rotated', providerId: 'alternative');
+    expect((await repository.selectById(alternative.id!)).status, BankConnectionStatus.reauthRequired);
+  });
+
+  test('reconnect changes UID without duplicating account history', () async {
+    final staged = await _stage(repository, authorizationId: 'auth-1');
+    final first = await repository.activateStagedConnection(staged.id!, [
+      BankAccountLink(uid: 'uid-old', identificationHashes: const {'hash-main', 'hash-alias'}, iban: 'IT00TEST', newAccount: _draft('Checking', startingValue: 42)),
+      BankAccountLink(uid: 'uid-removed', identificationHashes: const {'hash-removed'}, newAccount: _draft('Removed')),
+    ]);
+    final originalRows = await db.query(bankAccountTable, where: '${BankAccountFields.ebConnectionId} = ?', whereArgs: [first.id], orderBy: BankAccountFields.id);
+    final originalId = originalRows.first[BankAccountFields.id] as int;
+    final removedId = originalRows.last[BankAccountFields.id] as int;
+
+    await repository.stageConnection(providerId: 'enable_banking', authorizationId: 'auth-2', applicationId: 'app-id', institutionName: 'Test Bank', institutionCountry: 'IT', remoteConnectionId: 'session-new', validUntil: DateTime.utc(2026, 12, 1), psuType: 'personal', reconnectConnectionId: first.id);
+    final beforeCommit = await repository.selectById(first.id!);
+    expect(beforeCommit.remoteConnectionId, 'session-old');
+    expect(beforeCommit.pendingRemoteConnectionId, 'session-new');
+    expect(beforeCommit.status, BankConnectionStatus.active);
+    expect((await repository.selectActive(applicationId: 'app-id')).single.id, first.id);
+
+    final reconnected = await repository.activateStagedConnection(first.id!, [
+      const BankAccountLink(uid: 'uid-new', identificationHashes: {'hash-alias', 'hash-new'}, iban: 'IT00UPDATED'),
+      BankAccountLink(uid: 'uid-added', identificationHashes: const {'hash-added'}, newAccount: _draft('Added')),
+    ]);
+
+    expect(reconnected.remoteConnectionId, 'session-new');
+    expect(reconnected.pendingRemoteConnectionId, isNull);
+    expect(reconnected.status, BankConnectionStatus.active);
+    final retained = (await db.query(bankAccountTable, where: '${BankAccountFields.id} = ?', whereArgs: [originalId])).single;
+    expect(retained[BankAccountFields.ebAccountUid], 'uid-new');
+    expect(retained[BankAccountFields.startingValue], 42);
+    expect(retained[BankAccountFields.name], 'Checking');
+    final removed = (await db.query(bankAccountTable, where: '${BankAccountFields.id} = ?', whereArgs: [removedId])).single;
+    expect(removed[BankAccountFields.ebConnectionId], isNull);
+    expect(removed[BankAccountFields.ebAccountUid], isNull);
+    expect(await db.query(bankAccountTable), hasLength(3));
+  });
+
+  test('identity collision rolls back every reconnect change', () async {
+    final staged = await _stage(repository, authorizationId: 'auth-1');
+    final active = await repository.activateStagedConnection(staged.id!, [
+      BankAccountLink(uid: 'uid-a', identificationHashes: const {'hash-a'}, newAccount: _draft('A')),
+      BankAccountLink(uid: 'uid-b', identificationHashes: const {'hash-b'}, newAccount: _draft('B')),
+    ]);
+    await repository.stageConnection(providerId: 'enable_banking', authorizationId: 'auth-2', applicationId: 'app-id', institutionName: 'Test Bank', institutionCountry: 'IT', remoteConnectionId: 'session-new', validUntil: DateTime.utc(2026, 12, 1), psuType: 'personal', reconnectConnectionId: active.id);
+
+    await expectLater(
+      () => repository.activateStagedConnection(active.id!, const [
+        BankAccountLink(uid: 'uid-collision', identificationHashes: {'hash-a', 'hash-b'}),
+      ]),
+      throwsA(isA<BankReconciliationException>().having((error) => error.failure, 'failure', BankReconciliationFailure.identityCollision)),
+    );
+
+    final accounts = await db.query(bankAccountTable, orderBy: BankAccountFields.id);
+    expect(accounts.map((row) => row[BankAccountFields.ebAccountUid]), ['uid-a', 'uid-b']);
+    final connection = await repository.selectById(active.id!);
+    expect(connection.remoteConnectionId, 'session-old');
+    expect(connection.pendingRemoteConnectionId, 'session-new');
+  });
+
+  test('missing stable identity does not partially insert an account', () async {
+    final staged = await _stage(repository, authorizationId: 'auth-1');
+    await expectLater(() => repository.activateStagedConnection(staged.id!, [BankAccountLink(uid: 'uid', identificationHashes: const {}, newAccount: _draft('Unsafe'))]), throwsA(isA<BankReconciliationException>()));
+    expect(await db.query(bankAccountTable), isEmpty);
+    expect((await repository.selectById(staged.id!)).status, BankConnectionStatus.awaitingImport);
+  });
+
+  test('empty selection cannot activate an invisible connection', () async {
+    final staged = await _stage(repository, authorizationId: 'auth-1');
+
+    await expectLater(() => repository.activateStagedConnection(staged.id!, const []), throwsA(isA<BankReconciliationException>()));
+    expect((await repository.selectById(staged.id!)).status, BankConnectionStatus.awaitingImport);
+  });
+
+  test('selectActive expires the exact UTC boundary atomically', () async {
+    final boundary = DateTime.utc(2026, 9, 1, 12);
+    final expired = await repository.insert(_activeConnection('expired', boundary));
+    final future = await repository.insert(_activeConnection('future', boundary.add(const Duration(seconds: 1))));
+
+    final active = await repository.selectActive(applicationId: 'app-id', clock: boundary);
+
+    expect(active.map((item) => item.id), [future.id]);
+    expect((await repository.selectById(expired.id!)).status, BankConnectionStatus.expired);
+  });
+
+  test('active selection and credential rotation are application-scoped', () async {
+    final current = await repository.insert(_activeConnection('current', DateTime.utc(2027)));
+    final old = await repository.insert(BankConnection(providerId: 'enable_banking', institutionName: 'Old Bank', institutionCountry: 'IT', applicationId: 'old-app', remoteConnectionId: 'old', validUntil: DateTime.utc(2027), status: BankConnectionStatus.active));
+
+    final selected = await repository.selectActive(applicationId: 'app-id');
+    expect(selected.map((item) => item.id), [current.id]);
+
+    await repository.markOtherApplicationsReauthRequired('app-id', providerId: 'enable_banking');
+    expect((await repository.selectById(old.id!)).status, BankConnectionStatus.reauthRequired);
+    expect((await repository.selectById(current.id!)).status, BankConnectionStatus.active);
+  });
+
+  test('local disconnect is distinct from confirmed remote revocation', () async {
+    final local = await repository.insert(_activeConnection('local', DateTime.utc(2027)));
+    final remote = await repository.insert(_activeConnection('remote', DateTime.utc(2027)));
+
+    await repository.disconnectLocally(local.id!);
+    await repository.finalizeRemoteRevocation(remote.id!);
+
+    expect((await repository.selectById(local.id!)).status, BankConnectionStatus.disconnected);
+    expect((await repository.selectById(remote.id!)).status, BankConnectionStatus.revoked);
+  });
+}
+
+Future<BankConnection> _stage(BankConnectionRepository repository, {required String authorizationId}) => repository.stageConnection(providerId: 'enable_banking', authorizationId: authorizationId, applicationId: 'app-id', institutionName: 'Test Bank', institutionCountry: 'IT', remoteConnectionId: 'session-old', validUntil: DateTime.utc(2026, 10, 1), psuType: 'personal');
+
+BankConnection _activeConnection(String remoteConnectionId, DateTime validUntil) => BankConnection(providerId: 'enable_banking', institutionName: 'Test Bank', institutionCountry: 'IT', applicationId: 'app-id', remoteConnectionId: remoteConnectionId, validUntil: validUntil, status: BankConnectionStatus.active);
+
+BankAccount _draft(String name, {num startingValue = 0}) => BankAccount(name: name, symbol: 'wallet', color: 1, startingValue: startingValue, active: true, countNetWorth: true, mainAccount: false, order: 0);

--- a/test/widget/accounts_sum_test.dart
+++ b/test/widget/accounts_sum_test.dart
@@ -19,7 +19,7 @@ void main() {
   late SharedPreferences sharedPreferences;
 
   setUpAll(() async {
-    sossoldiDatabase = SossoldiDatabase(dbName: 'test.db');
+    sossoldiDatabase = SossoldiDatabase(dbName: 'accounts_sum_test.db');
     await sossoldiDatabase.clearDatabase();
     SharedPreferences.setMockInitialValues({'visibility_amount': false});
     sharedPreferences = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary

Adds persistence and consent lifecycle management on top of the banking foundation introduced in #536.

- Persist bank connections, provider identity, and pending authorization state, with migrations and compatibility for existing stored data.
- Handle authorization callbacks, interrupted-flow recovery, reconnect, and revocation through provider-neutral banking contracts.
- Integrate credential settings and lifecycle coordination in the application layer, keeping Enable Banking-specific behavior in its adapter.

This is the second PR in the banking integration series for #481. User-facing setup and connection flows will be introduced in the later UI PR.

## Commit structure

1. Validate consent redirects and map connection failures.
2. Persist bank connections and recovery state.
3. Integrate the provider-neutral consent lifecycle.
